### PR TITLE
Escape backslash in macOS Application Support path

### DIFF
--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -127,7 +127,7 @@ all your changes may be lost if you uninstall or upgrade Mixxx.
 Instead, copy the default mapping file to the following location:
 
 * Linux: :file:`~/.mixxx/Custom.kbd.cfg`
-* macOS: :file:`~/Library/Application\ Support/Mixxx/Custom.kbd.cfg`
+* macOS: :file:`~/Library/Application\\ Support/Mixxx/Custom.kbd.cfg`
 * Windows: :file:`%LOCALAPPDATA%\\Mixxx\\Custom.kbd.cfg`
 
 Then edit this file and save the changes. On the next startup, Mixxx will check

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -74,7 +74,7 @@ There are also some advanced options in the Midi Wizard you may need to use:
 The Controller wizard saves the new preset to the following file paths:
 
 * Linux: :file:`/home/<username>/.mixxx/controllers`
-* macOS: :file:`/Users/<username>/Library/Application\ Support/Mixxx/controllers`
+* macOS: :file:`/Users/<username>/Library/Application\\ Support/Mixxx/controllers`
 * Windows: :file:`%LOCALAPPDATA%\\Mixxx\\controllers`
 
 You can then modify the XML file it creates (or any of the ones that


### PR DESCRIPTION
Without this escape, the path [currently shows up](https://mixxx.org/manual/2.2/en/chapters/advanced_topics.html#controller-wizard) without the space, which is incorrect. I guess ReST interprets the backslash as an escape sequence, even inside the code snippet.