### PR TITLE
Travis CI: Split up HTML/PDF builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,39 @@ cache:
 if: type != pull_request AND branch =~ /^(manual-)/
 
 install:
-- sudo apt-get update && sudo apt-get install -y texlive texlive-xetex texlive-latex-extra latexmk xindy
-- npm install -g netlify-cli
-- export PATH="$(npm prefix -g)/bin:$PATH"
 - pip install -r requirements.txt
 
-script:
-- mkdir html
-- git remote rename origin fork
-- git remote add origin https://github.com/mixxxdj/manual.git
-- git fetch origin
+before_script:
+- git clone https://github.com/mixxxdj/manual.git manual
+- cd manual
 - git branch -r
 - export LATEST_BRANCH="$(git branch -r | grep -Po 'origin/manual-\d+\.\d+\.x' | sort | tail -n 1)"
 - echo "Building from branch ${LATEST_BRANCH}"
 - git checkout "${LATEST_BRANCH}"
-- sh build_manual.sh
 
-deploy:
-  provider: script
-  skip_cleanup: true
-  script: netlify deploy --prod --dir build/html
+jobs:
+  include:
+    - name: HTML
+      script:
+      - sh ../build_html.sh
+      before_deploy:
+      - npm install -g netlify-cli
+      - export PATH="$(npm prefix -g)/bin:$PATH"
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script: netlify deploy --prod --dir build/html
+        on:
+          all_branches: true
+
+    - name: PDF
+      script:
+      - sh ../build_pdf.sh
+      addons:
+        apt:
+          packages:
+            - texlive
+            - texlive-xetex
+            - texlive-latex-extra
+            - latexmk
+            - xindy

--- a/build_html.sh
+++ b/build_html.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Parse languages and ensure that "en" is built last
+# This is necessary because we generate the redirect rules in the same loop
+# and want to use "en" as a fallback.
 cd source || exit 1
 LANGUAGES="$(python -c 'import conf; print(" ".join(sorted((lang for lang in conf.supported_languages.keys() if lang != "en"), reverse=True)))')"
 cd .. || exit 1

--- a/build_html.sh
+++ b/build_html.sh
@@ -22,13 +22,6 @@ do
     else
         printf '/:version/* /:version/%s/:splat    301 Language=%s\n' "$lang" "$lang" >> build/html/_redirects
     fi
-    make versionedhtml SPHINXOPTS="-Q -j $(nproc) -Dlanguage=$lang"
-    make versionedlatexpdf SPHINXOPTS="-Q -j $(nproc) -Dlanguage=$lang" >/dev/null
+    make versionedhtml SPHINXOPTS="-j $(nproc) -Dlanguage=$lang"
     i=$((i + 1))
-done
-
-cd build/latex || exit 1
-for file in */*/Mixxx-Manual.pdf
-do
-    cp "$file" "../html/$file"
 done

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Parse languages and ensure that "en" is built last
+cd source || exit 1
+LANGUAGES="$(python -c 'import conf; print(" ".join(sorted((lang for lang in conf.supported_languages.keys() if lang != "en"), reverse=True)))')"
+cd .. || exit 1
+LANGUAGES="$LANGUAGES en"
+NUM_LANGUAGES="$(printf '%s' "$LANGUAGES" | wc -w)"
+
+i=1
+for lang in $LANGUAGES
+do
+    printf -- '----- Building language "%s"... [%d/%d] -----\n' "$lang" "$i" "$NUM_LANGUAGES"
+    make versionedlatexpdf SPHINXOPTS="-Q -j $(nproc) -Dlanguage=$lang" >/dev/null
+    i=$((i + 1))
+done
+
+cd build/latex || exit 1
+mkdir ../pdf
+for file in */*/Mixxx-Manual.pdf
+do
+    newfilename="mixxx-manual-$(dirname "$file" | tr "/" "-")"
+    cp "$file" "../pdf/${newfilename}.pdf"
+done
+find ../pdf -type f

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -1,9 +1,7 @@
-#!/bin/sh
-# Parse languages and ensure that "en" is built last
+# Parse languages
 cd source || exit 1
-LANGUAGES="$(python -c 'import conf; print(" ".join(sorted((lang for lang in conf.supported_languages.keys() if lang != "en"), reverse=True)))')"
+LANGUAGES="$(python -c 'import conf; print(" ".join(sorted((lang for lang in conf.supported_languages.keys()), reverse=True)))')"
 cd .. || exit 1
-LANGUAGES="$LANGUAGES en"
 NUM_LANGUAGES="$(printf '%s' "$LANGUAGES" | wc -w)"
 
 i=1


### PR DESCRIPTION
This now builds HTML and PDF manuals separately, as the combined build exceeds maximum build time on Travis CI. The HTML is deployed to Netlify. The PDFs are not deployed right now, but could be uploaded to downloads.mixxx.org (adding files to existing deployments are not possible on Netlify). 