### PR TITLE
Corrected error in Chapter 3 - Waveform Displays (2.3.x)

### DIFF
--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -113,8 +113,9 @@ visually by aligning the beats that appear in each waveform.
    Mixxx default skin (Latenight) - Parallel waveforms
 
 Depending on the skin, Mixxx displays either parallel waveforms (default) or
-separate waveforms. Select your preferred appearance in
-:menuselection:`Preferences --> Interface --> Skin`.
+separate waveforms. You can select your preferred appearance by clicking the 
+gear icon in the upper right corner. Then under Skin Settings, click/toggle 
+the Parallel Waveforms option to choose between parallel or separate waveform.
 
 .. figure:: ../_static/Mixxx-200-Deere-separate-waveform.png
    :align: center


### PR DESCRIPTION
Under the sub section "Waveform Displays" in Chapter 3 of the manual, it says "Depending on the skin, Mixxx displays either parallel waveforms (default) or separate waveforms. Select your preferred appearance in Preferences ‣ Interface ‣ Skin." This is not right

The correct way is by clicking the gear icon in the upper right corner. Then under Skin Settings, click/toggle the Parallel Waveforms option to choose between parallel or separate waveform. 

Correction made. I've done this for 2.2.x as well. @Holzhaus , waiting for your approval...