### PR TITLE
Fixing Glossary.rst

### DIFF
--- a/source/chapters/preferences.rst
+++ b/source/chapters/preferences.rst
@@ -164,15 +164,15 @@ CoreAudio is the only Sound API on macOS.
 Other Sound Hardware options
 ----------------------------
 * **Multi-Soundcard Synchronization**: Mixxx is able to use two or more
-  :term:`audio interfaces` at a time, each with its own clock. When multiple
+  :term:`audio interface <audio interface>` at a time, each with its own clock. When multiple
   audio interfaces are in use, the Mixxx engine is driven by the Master
   audio interface. Here you can select the synchronization used for the other
   audio interfaces to avoid buffer overflows or underflows.
 
 * **Keylock/Pitch-Bending Engine**: This allows you to select the engine used
-  for independent tempo and pitch changes (e.g. :term:`keylock`). Use
+  for independent tempo and pitch changes (e.g. :term:`key lock`). Use
   :menuselection:`Soundtouch` on lower power machines (such as netbooks) or if
-  you experience buffer underflows while using :term:`keylock`.
+  you experience buffer underflows while using :term:`key lock`.
 
 * **Master Mix**: You may disable the master mix to reduce Mixxx's CPU usage if
   you do not use the Master output, recording or live broadcasting.

--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -235,7 +235,7 @@ follows:
   :term:`quantized <quantization>` so that they begin on a beat.
 
 **Keylock Toggle**
-  :term:`Keylock <key lock>` locks the track's pitch so that adjustments to its
+  :term:`Key lock <key lock>` locks the track's pitch so that adjustments to its
   tempo via the rate slider do not affect its pitch. This is useful if you would
   like to speed up or slow down a track and avoid the “chipmunk” effect that
   speeding up vocals has.
@@ -1009,7 +1009,7 @@ are as follows:
   This control determines the sampler input's mix orientation.
 
 **Keylock Toggle**
-  :term:`Keylock <key lock>` locks the track's pitch so that adjustments to its
+  :term:`Key lock <key lock>` locks the track's pitch so that adjustments to its
   tempo via the rate slider do not affect its pitch.
 
 Sample Deck Controls

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -34,7 +34,6 @@ Glossary of Terms
      is useful because they allow DJs to see breakdowns far in advance.
 
    key lock
-   keylock
      With key lock enabled, the tempo of the track will change but the pitch
      remains consistent.  When unlocked, the pitch slider will speed up (or slow
      down) the track and the pitch will increase (or decrease) along with it.
@@ -337,7 +336,6 @@ Glossary of Terms
      are relieved of the task of having to compile the code by yourself.
 
    audio interface
-   audio interfaces
      An audio interface is a device that facilitates the input and output of
      audio signals to and from a computer, typically connected by USB. Almost
      all computers come with a basic audio interface built in, but a higher
@@ -345,12 +343,11 @@ Glossary of Terms
      Mixxx.
 
    soundcard
-   soundcards
      Another name for an :term:`audio interface`, although few audio interfaces
      are shaped like cards anymore.
 
    direct monitoring
-     A feature of many :term:`soundcards` that allows microphones and other
+     A feature of many :term:`soundcards <soundcard>` that allows microphones and other
      input signals to be heard through the soundcard outputs with no
      perceivable latency. With direct monitoring, the audio interface mixes the
      input signal in hardware with the output signal from Mixxx. This
@@ -465,7 +462,7 @@ Glossary of Terms
      An Application Program Interface (API) is a specification and set of rules
      for how software programs interact with each other. In Mixxx, an example of
      this is the Sound API that Mixxx uses to communicate with the
-     :term:`operating system` to make use of the :term:`soundcards` connected to
+     :term:`operating system` to make use of the :term:`soundcards <soundcard>` connected to
      the computer.
 
    macOS


### PR DESCRIPTION
While going through the manual for version 2.2 I noticed glossary had some unnecessary repetition. Some words occurred twice.