### PR TITLE
Updating instruction on accessing the Waveforms menu item

### DIFF
--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -130,7 +130,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 
 .. warning :: If you have a slower computer and notice performance issues with
               Mixxx, try lowering the frame rate or changing the waveform type
-              in :menuselection:`Preferences --> Interface --> Waveforms`.
+              in :menuselection:`Preferences --> Waveforms`.
 
 **Waveform summary**
   The big waveform summary shows the waveform envelope of the track near the
@@ -141,8 +141,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 
   .. hint :: You can select from different types of displays for the waveform,
              which differ primarily in the level of detail shown in the
-             waveform, in :menuselection:`Preferences --> Interface -->
-             Waveforms --> Summary type`.
+             waveform, in :menuselection:`Preferences --> Waveforms --> Summary type`.
 
 **Waveform overview**
   The smaller, zoomed-out version of the waveform shows the various markers
@@ -153,7 +152,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
   Clicking somewhere on the waveform allows you to jump to an arbitrary position
   in the track. Like with the Waveform summary, you can select from different
   types of displays for the overview in
-  :menuselection:`Preferences --> Interface --> Waveforms --> Overview type`.
+  :menuselection:`Preferences --> Waveforms --> Overview type`.
 
 **Vinyl Widget**
   The line on the vinyl widget rotates if the track moves. It is similar to the
@@ -171,7 +170,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 **Waveform Zoom**
   Using the mouse-wheel everywhere in the waveform summary will zoom the
   waveform in or out. You can choose whether to synchronize the zoom level
-  between the decks in :menuselection:`Preferences --> Interface --> Waveforms`.
+  between the decks in :menuselection:`Preferences --> Waveforms`.
 
 **Waveform Marker**
   While mixing, various additional markers can appear on the waveforms:

--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -141,7 +141,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 
   .. hint :: You can select from different types of displays for the waveform,
              which differ primarily in the level of detail shown in the
-             waveform, in :menuselection:`Preferences --> Waveforms --> Summary type`.
+             waveform, in :menuselection:`Preferences --> Waveforms --> Waveform type`.
 
 **Waveform overview**
   The smaller, zoomed-out version of the waveform shows the various markers

--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -132,6 +132,17 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
               Mixxx, try lowering the frame rate or changing the waveform type
               in :menuselection:`Preferences --> Waveforms`.
 
+**Waveform summary**
+  The big waveform summary shows the waveform envelope of the track near the
+  current playback position and is updated in real time. The mouse can be used
+  on the waveform to pause, scratch, spin-back or throw the tracks.
+  Right-clicking on the waveforms allows you to drag with the mouse to make
+  temporary pitch adjustments.
+
+  .. hint :: You can select from different types of displays for the waveform,
+             which differ primarily in the level of detail shown in the
+             waveform, in :menuselection:`Preferences --> Waveforms --> Summary type`.
+
 **Waveform overview**
   The smaller, zoomed-out version of the waveform shows the various markers
   within the track as well as the waveform envelope of the entire track. This is
@@ -139,8 +150,8 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
   the part of the track that has already been played is darkened.
 
   Clicking somewhere on the waveform allows you to jump to an arbitrary position
-  in the track. You can select from different types of displays for the overview,  
-  which differ primarily in the level of detail shown in the waveform, in
+  in the track. Like with the Waveform summary, you can select from different
+  types of displays for the overview in
   :menuselection:`Preferences --> Waveforms --> Overview type`.
 
 **Vinyl Widget**
@@ -157,7 +168,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
   Vinyl Control --> Show Signal Quality in Skin`.
 
 **Waveform Zoom**
-  Using the mouse-wheel everywhere in the waveform overview will zoom the
+  Using the mouse-wheel everywhere in the waveform summary will zoom the
   waveform in or out. You can choose whether to synchronize the zoom level
   between the decks in :menuselection:`Preferences --> Waveforms`.
 
@@ -167,7 +178,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 * **Position marker**: The static vertical line in the center of the waveform
   summary indicates the playback point of the deck. The waveform overview
   includes a vertical line to show the current position within the track.
-* **Beat marker**: The regular white lines on the waveform overview indicate the
+* **Beat marker**: The regular white lines on the waveform summary indicate the
   locations of beats in the audio, also called the :term:`beatgrid`.
 * **Cue marker**: Indicates the position of the :term:`cue point <cue>`.
 * **Hotcue marker**: Indicate the position and number of a :term:`hotcue`

--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -132,17 +132,6 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
               Mixxx, try lowering the frame rate or changing the waveform type
               in :menuselection:`Preferences --> Waveforms`.
 
-**Waveform summary**
-  The big waveform summary shows the waveform envelope of the track near the
-  current playback position and is updated in real time. The mouse can be used
-  on the waveform to pause, scratch, spin-back or throw the tracks.
-  Right-clicking on the waveforms allows you to drag with the mouse to make
-  temporary pitch adjustments.
-
-  .. hint :: You can select from different types of displays for the waveform,
-             which differ primarily in the level of detail shown in the
-             waveform, in :menuselection:`Preferences --> Waveforms --> Summary type`.
-
 **Waveform overview**
   The smaller, zoomed-out version of the waveform shows the various markers
   within the track as well as the waveform envelope of the entire track. This is
@@ -150,8 +139,8 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
   the part of the track that has already been played is darkened.
 
   Clicking somewhere on the waveform allows you to jump to an arbitrary position
-  in the track. Like with the Waveform summary, you can select from different
-  types of displays for the overview in
+  in the track. You can select from different types of displays for the overview,  
+  which differ primarily in the level of detail shown in the waveform, in
   :menuselection:`Preferences --> Waveforms --> Overview type`.
 
 **Vinyl Widget**
@@ -168,7 +157,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
   Vinyl Control --> Show Signal Quality in Skin`.
 
 **Waveform Zoom**
-  Using the mouse-wheel everywhere in the waveform summary will zoom the
+  Using the mouse-wheel everywhere in the waveform overview will zoom the
   waveform in or out. You can choose whether to synchronize the zoom level
   between the decks in :menuselection:`Preferences --> Waveforms`.
 
@@ -178,7 +167,7 @@ then toggling the :menuselection:`Skin Settings --> Parallel Waveforms` option.
 * **Position marker**: The static vertical line in the center of the waveform
   summary indicates the playback point of the deck. The waveform overview
   includes a vertical line to show the current position within the track.
-* **Beat marker**: The regular white lines on the waveform summary indicate the
+* **Beat marker**: The regular white lines on the waveform overview indicate the
   locations of beats in the audio, also called the :term:`beatgrid`.
 * **Cue marker**: Indicates the position of the :term:`cue point <cue>`.
 * **Hotcue marker**: Indicate the position and number of a :term:`hotcue`

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -25,10 +25,6 @@ Glossary of Terms
      headphones by lowering the volume fader so the deck plays only to
      headphones but not to the audience. See also: :term:`headphone button`.
 
-   waveform summary
-     The waveform summary shows the waveform envelope of the track near the
-     current playback position.
-
    waveform overview
      The waveform overview shows the waveform envelope of the entire track, and
      is useful because they allow DJs to see breakdowns far in advance.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -25,6 +25,10 @@ Glossary of Terms
      headphones by lowering the volume fader so the deck plays only to
      headphones but not to the audience. See also: :term:`headphone button`.
 
+   waveform summary
+     The waveform summary shows the waveform envelope of the track near the
+     current playback position.
+
    waveform overview
      The waveform overview shows the waveform envelope of the entire track, and
      is useful because they allow DJs to see breakdowns far in advance.


### PR DESCRIPTION
Made changes in chapter 3 to make it easier for users to access the "Waveforms" menu item. In the manual currently, it says Preferences > Interface > Waveforms, it should be Preferences > Waveforms as Waveforms isn't in the Interface settings section but on its own in the sidebar. 

I think "Options" should be added before "Preferences" (Options > Preferences) wherever such a case occur making it easier for users to find the "Preferences" menu item. If this is approved, I can add the changes to this request or create another request for it