### PR TITLE
pre-commit: Remove check-merge-conflict hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
   hooks:
   - id: check-byte-order-marker
   - id: check-case-conflict
-  - id: check-merge-conflict
   - id: end-of-file-fixer
   - id: mixed-line-ending
   - id: trailing-whitespace


### PR DESCRIPTION
This may interfere with RST's headline syntax in some rare circumstances, so let's disable it.