### PR TITLE
Use sphinxcontrib.rsvgconverter instead of sphinx.ext.imgconverter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
       addons:
         apt:
           packages:
+            - librsvg2-bin
             - fonts-freefont-otf
             - texlive
             - texlive-generic-recommended

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sphinx-intl
 graphviz
 markupsafe
 transifex-client
+sphinxcontrib-svg2pdfconverter
 sphinx-rtd-theme==0.4.3
 sphinx-multiversion==0.2.1
 ./sphinx-mixxx

--- a/source/conf.py
+++ b/source/conf.py
@@ -32,7 +32,7 @@ import sphinx_rtd_theme
 extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.graphviz",
-    "sphinx.ext.imgconverter",
+    "sphinxcontrib.rsvgconverter",
     "sphinx_rtd_theme",
     "sphinx_multiversion",
     "sphinx_mixxx",


### PR DESCRIPTION
Since LaTeX doesn't support SVG files, we need to convert them to a
format that it can understand. Until now, we used
`sphinx.ext.imgconverter` for that. Unfortunately, that has various
issues:

- It depends on ImageMagick which is buggy on some platforms (e.g. on
  the `ubuntu-latest` image in GitHub Actions)
- SVGs are rasterized, so that you can't zoom in losslessly in PDFs
- Rasterization also happens for HTML documentation, even though it's
  unnecessary

By replacing it with `sphinxcontrib.rsvgconverter`, all of these are
fixed. For LaTeX, this converts the SVG to a vector PDF which can be
used with `\includegraphics{}`.

What it doesn't do is converting GIF images. These also cause problems
with the LaTeX build, but we didn't notice that because
`sphinx.ext.imgconverter` converted them as well. Fortunately, we only
have 2 GIF images in our source tree and can just use a different
format. Hence, this PR depends on #298 and #297.