### PR TITLE
chapters/controlling_mixxx: Reorder controller preset instructions

### DIFF
--- a/source/chapters/controlling_mixxx.rst
+++ b/source/chapters/controlling_mixxx.rst
@@ -114,9 +114,9 @@ Without loading the correct preset, your controller does not work with Mixxx.
 #. Go to :menuselection:`Preferences --> Controllers`
 #. Select your device from the list of available devices on the left, and the
    right pane will change
-#. Activate the :guilabel:`Enabled` checkbox
 #. Select the mapping for your controller from the :guilabel:`Load Preset`
    drop-down menu
+#. Activate the :guilabel:`Enabled` checkbox
 #. Click :guilabel:`Apply` and Mixxx can now be controlled by your controller(s).
 #. Repeat step 4-7 for any of the controllers you want to use
 

--- a/source/chapters/controlling_mixxx.rst
+++ b/source/chapters/controlling_mixxx.rst
@@ -116,7 +116,7 @@ Without loading the correct preset, your controller does not work with Mixxx.
    right pane will change
 #. Select the mapping for your controller from the :guilabel:`Load Preset`
    drop-down menu
-#. Activate the :guilabel:`Enabled` checkbox
+#. Make sure that the :guilabel:`Enabled` checkbox is ticked
 #. Click :guilabel:`Apply` and Mixxx can now be controlled by your controller(s).
 #. Repeat step 4-7 for any of the controllers you want to use
 


### PR DESCRIPTION
The controller preset setup was improved in Mixxx 2.3. Now, when no
preset is selected, the "Enabled" checkbox is greyed out. Hence it it's
necessary to select a mapping *before* ticking the checkbox.