### PR TITLE
Allow failure on linkcheck

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -7,6 +7,7 @@ jobs:
   linkcheck:
     name: Link Check
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - name: Clone repository
       uses: actions/checkout@v2


### PR DESCRIPTION
I changed the linkcheck on the CI. It now continue even if it failed. I need your validation about it.

I did it because www.stantondj.com is down, so we can't build.

It's nice to have a check, but we can't control the Internet :o

