### PR TITLE
Behringer B-CONTROL Deejay BCD3000: Remove broken manual link

### DIFF
--- a/source/hardware/controllers/behringer_b_control_deejay_bcd3000.rst
+++ b/source/hardware/controllers/behringer_b_control_deejay_bcd3000.rst
@@ -4,7 +4,6 @@ Behringer B-Control Deejay BCD 3000
 ===================================
 
   - `Manufacturer's page <https://www.behringer.com/product.html?modelCode=P0758>`__
-  - `Manual <https://www.parts-express.com/pedocs/manuals/248-6084-behringer-bcd3000-manual-42714.pdf>`__
 
 By default, the input channels 1-2 use the RCA phono inputs for the
 source signal. On Windows, this can be switched to the microphone in the


### PR DESCRIPTION
Thr link gives a 404 and goes to a third party site. The manual is
still available on the official product page.