### PR TITLE
Partly fix issue Document missing Mixxx Controls #261

### DIFF
--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -590,7 +590,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [SamplerN],beat_closest
 
 
-   Its value is set to the position of the closest beat of the active beat and is used for updating the beat leds
+   Its value is set to the sample position of the closest beat of the active beat and is used for updating the beat LEDs.
    :range: -1, 0.0, real-valued
    :feedback: None
 

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -598,8 +598,8 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],beat_distance
                    [SamplerN],beat_distance
 
-   Outputs the distance to the nearest beat of the active beat.
-   :range: 0.0, real-valued
+   Outputs the relative position of the play marker in the section between the the previous and next beat marker.
+   :range: 0.0 - 1.0, real-valued
    :feedback: None
 
 

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -988,7 +988,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_indicator
                    [SamplerN],cue_indicator
 
-   Provides information to be bound to the :guilabel:`Cue` Button e.g. blinking when next press will move the :term:`cue point`.
+   Indicates the blinking pattern of the :guilabel:`CUE` button (i.e. 1.0 if the button is illuminated, 0.0 otherwise), depending on the chosen :mixxx:coref:`cue mode <[ChannelN],cue_mode>`.
 
    :range: binary
    :feedback: :guilabel:`Cue` button

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -999,7 +999,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_mode
                    [SamplerN],cue_mode
 
-   Decides which cue mode to call based on the user preference and compatible hardware.
+   Represents the currently chosen :ref:`cue mode <interface-cue-modes>`.
 
    :range:
       ===== =============================

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -585,6 +585,24 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
    .. versionadded:: 1.10.0
 
 
+.. mixxx:control:: [ChannelN],beat_closest
+                   [PreviewDeckN],beat_closest
+                   [SamplerN],beat_closest
+
+                 
+   Its value is set to the position of the closest beat of the active beat and is used for updating the beat leds
+   :range: -1, 0.0, real-valued
+   :feedback: None
+
+.. mixxx:control:: [ChannelN],beat_distance
+                   [PreviewDeckN],beat_distance
+                   [SamplerN],beat_distance
+                 
+   Outputs the distance to the nearest beat of the active beat.
+   :range: 0.0, real-valued
+   :feedback: None
+
+
 .. mixxx:control:: [ChannelN],beatjump
                    [PreviewDeckN],beatjump
                    [SamplerN],beatjump
@@ -900,6 +918,38 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
    .. versionadded:: 2.3.0
 
 
+.. mixxx:control:: [ChannelN],cue_cdj
+                   [PreviewDeckN],cue_cdj
+                   [SamplerN],cue_cdj
+
+   Represents a :guilabel:`Cue` button that is always in :term:`CDJ` mode.
+
+   :range: binary
+   :feedback: None
+
+   .. versionadded:: 1.10.0
+
+
+.. mixxx:control:: [ChannelN],cue_clear
+                   [PreviewDeckN],cue_clear
+                   [SamplerN],cue_clear
+
+   Releases the already set cue point and sets cue value to 0.
+   
+   :range: binary
+   :feedback: None
+
+
+.. mixxx:control:: [ChannelN],cue_goto
+                   [PreviewDeckN],cue_goto
+                   [SamplerN],cue_goto
+
+   If the cue point is set, recalls the cue point.
+   
+   :range: binary
+   :feedback: Player may change position
+
+
 .. mixxx:control:: [ChannelN],cue_default
                    [PreviewDeckN],cue_default
                    [SamplerN],cue_default
@@ -938,24 +988,34 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_indicator
                    [SamplerN],cue_indicator
 
-   Provides information to be bound to the :guilabel:`Cue` Button e.g. blinking when next press will move the :term:`cue point`
+   Provides information to be bound to the :guilabel:`Cue` Button e.g. blinking when next press will move the :term:`cue point`.
 
    :range: binary
    :feedback: :guilabel:`Cue` button
 
    .. versionadded:: 2.0.0
 
+.. mixxx:control:: [ChannelN],cue_mode
+                   [PreviewDeckN],cue_mode
+                   [SamplerN],cue_mode
 
-.. mixxx:control:: [ChannelN],cue_cdj
-                   [PreviewDeckN],cue_cdj
-                   [SamplerN],cue_cdj
+   Decides which cue mode to call based on the user preference and compatible hardware.
+   
+   :range:
+      ===== =============================
+      Value compatible hardware
+      ===== =============================
+      0.0   Mixxx mode (default)
+      1.0   Pioneer mode
+      2.0   Denon mode
+      3.0   Numark mode
+      4.0   Mixxx mode (no blinking)  
+      5.0   CUP (Cue + Play) mode
+      ===== =============================
 
-   Represents a :guilabel:`Cue` button that is always in :term:`CDJ` mode.
+   
 
-   :range: binary
    :feedback: None
-
-   .. versionadded:: 1.10.0
 
 
 .. mixxx:control:: [ChannelN],cue_play
@@ -974,7 +1034,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_point
                    [SamplerN],cue_point
 
-   The current position of the :term:`cue point` in samples
+   The current position of the :term:`cue point` in samples.
 
    :range: absolute value
    :feedback: Cue point marker
@@ -984,7 +1044,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_preview
                    [SamplerN],cue_preview
 
-   Plays from the current :term:`cue point`
+   Plays from the current :term:`cue point`.
 
    :range: binary
    :feedback: :guilabel:`Cue` button lights and waveform moves
@@ -994,7 +1054,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_set
                    [SamplerN],cue_set
 
-   Sets a :term:`cue point` at the current location
+   Sets a :term:`cue point` at the current location.
 
    :range: binary
    :feedback: :term:`Cue <cue>` mark appears on the waveform
@@ -1395,6 +1455,16 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
    :feedback: Track name & waveform change & Play/pause button
 
    .. versionadded:: 1.11.0
+
+
+.. mixxx:control:: [ChannelN],local_bpm
+                   [PreviewDeckN],local_bpm
+                   [SamplerN],local_bpm
+
+   Reflects the average bpm around the current play position of the loaded file.
+   
+   :range: positive value
+   :feedback: None
 
 
 .. mixxx:control:: [ChannelN],loop_double
@@ -3315,6 +3385,24 @@ Note that :mixxx:coref:`[Library],MoveUp` and other Move and Scroll controls emu
 
    .. versionadded:: 2.3.0
 
+The ``[Broadcast]`` controls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. mixxx:control:: [Shoutcast],enabled
+
+   This control shows if live Internet broadcasting is enabled with Shoutcast server connection. :term:`Shoutcast <shoutcast>` feeds to and from the stream. 
+   
+   :range: ?
+   :feedback: shoutcast only supports mp3 format as field
+
+
+.. mixxx:control:: [Shoutcast],status
+
+   This control displays whether broadcasting connection to Shoutcast server was successfully established.
+   
+   :range: binary
+   :feedback: None  
+
 
 The ``[Playlist]`` controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3364,10 +3452,11 @@ This group is going to be deprecated at some point, with its controls added to `
 
 
 .. mixxx:control:: [Playlist],SelectPrevPlaylist
+
     :range: binary
     :feedback: Library sidebar
 
-    Switches to the previous view (Library, Queue, etc.)
+   Switches to the previous view (Library, Queue, etc.)
 
     .. deprecated:: 2.1.0
        Use :mixxx:coref:`[Library],MoveUp` instead.
@@ -3429,6 +3518,19 @@ The :mixxx:cogroupref:`[Controls]` group contains controls that didn't fit in an
 
    .. versionadded:: 2.3.0
 
+.. mixxx:control:: [Controls],ShowDurationRemaining
+
+   Yields the current state of the remaining time duration of the loaded track.
+   
+   :range:
+      ===== ===========================================================================
+      Value Meaning
+      ===== ===========================================================================
+      0     currently showing elapsed time, sets to remaining time
+      1     currently showing remaining time , sets to elapsed time
+      2     currently showing both (that means we are showing remaining, set to elapsed
+      ===== ===========================================================================
+   :feedback: None
 
 .. _advanced-mixxxcontrols-effects:
 

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -3520,7 +3520,7 @@ The :mixxx:cogroupref:`[Controls]` group contains controls that didn't fit in an
 
 .. mixxx:control:: [Controls],ShowDurationRemaining
 
-   Yields the current state of the remaining time duration of the loaded track.
+   Represents the current state of the remaining time duration display of the loaded track.
 
    :range:
       ===== ===========================================================================

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -934,7 +934,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_clear
                    [SamplerN],cue_clear
 
-   Deletes the already set cue point and sets :mixxx:coref:`[ChannelN],cue` to 0.
+   Deletes the already set cue point and sets :mixxx:coref:`[ChannelN],cue_point` to -1.
 
    :range: binary
    :feedback: None

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -3385,7 +3385,7 @@ Note that :mixxx:coref:`[Library],MoveUp` and other Move and Scroll controls emu
 
    .. versionadded:: 2.3.0
 
-The ``[Broadcast]`` controls
+The ``[Shoutcast]`` controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. mixxx:control:: [Shoutcast],enabled

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -934,7 +934,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],cue_clear
                    [SamplerN],cue_clear
 
-   Releases the already set cue point and sets cue value to 0.
+   Deletes the already set cue point and sets :mixxx:coref:`[ChannelN],cue` to 0.
 
    :range: binary
    :feedback: None

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -589,7 +589,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],beat_closest
                    [SamplerN],beat_closest
 
-                 
+
    Its value is set to the position of the closest beat of the active beat and is used for updating the beat leds
    :range: -1, 0.0, real-valued
    :feedback: None
@@ -597,7 +597,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
 .. mixxx:control:: [ChannelN],beat_distance
                    [PreviewDeckN],beat_distance
                    [SamplerN],beat_distance
-                 
+
    Outputs the distance to the nearest beat of the active beat.
    :range: 0.0, real-valued
    :feedback: None
@@ -935,7 +935,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [SamplerN],cue_clear
 
    Releases the already set cue point and sets cue value to 0.
-   
+
    :range: binary
    :feedback: None
 
@@ -945,7 +945,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [SamplerN],cue_goto
 
    If the cue point is set, recalls the cue point.
-   
+
    :range: binary
    :feedback: Player may change position
 
@@ -1000,7 +1000,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [SamplerN],cue_mode
 
    Decides which cue mode to call based on the user preference and compatible hardware.
-   
+
    :range:
       ===== =============================
       Value compatible hardware
@@ -1009,11 +1009,11 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
       1.0   Pioneer mode
       2.0   Denon mode
       3.0   Numark mode
-      4.0   Mixxx mode (no blinking)  
+      4.0   Mixxx mode (no blinking)
       5.0   CUP (Cue + Play) mode
       ===== =============================
 
-   
+
 
    :feedback: None
 
@@ -1462,7 +1462,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [SamplerN],local_bpm
 
    Reflects the average bpm around the current play position of the loaded file.
-   
+
    :range: positive value
    :feedback: None
 
@@ -3390,8 +3390,8 @@ The ``[Broadcast]`` controls
 
 .. mixxx:control:: [Shoutcast],enabled
 
-   This control shows if live Internet broadcasting is enabled with Shoutcast server connection. :term:`Shoutcast <shoutcast>` feeds to and from the stream. 
-   
+   This control shows if live Internet broadcasting is enabled with Shoutcast server connection. :term:`Shoutcast <shoutcast>` feeds to and from the stream.
+
    :range: ?
    :feedback: shoutcast only supports mp3 format as field
 
@@ -3399,9 +3399,9 @@ The ``[Broadcast]`` controls
 .. mixxx:control:: [Shoutcast],status
 
    This control displays whether broadcasting connection to Shoutcast server was successfully established.
-   
+
    :range: binary
-   :feedback: None  
+   :feedback: None
 
 
 The ``[Playlist]`` controls
@@ -3521,7 +3521,7 @@ The :mixxx:cogroupref:`[Controls]` group contains controls that didn't fit in an
 .. mixxx:control:: [Controls],ShowDurationRemaining
 
    Yields the current state of the remaining time duration of the loaded track.
-   
+
    :range:
       ===== ===========================================================================
       Value Meaning

--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -3390,7 +3390,7 @@ The ``[Shoutcast]`` controls
 
 .. mixxx:control:: [Shoutcast],enabled
 
-   This control shows if live Internet broadcasting is enabled with Shoutcast server connection. :term:`Shoutcast <shoutcast>` feeds to and from the stream.
+   Shows if live Internet broadcasting is enabled.
 
    :range: ?
    :feedback: shoutcast only supports mp3 format as field


### PR DESCRIPTION
#261 Written documentation for the following controls in advanced topics:

- [x] [Controls],ShowDurationRemaining
- [x] [ChannelN],beat_closest
- [x] [ChannelN],beat_distance
- [x] [ChannelN],cue_clear
- [x] [ChannelN],cue_goto
- [x] [ChannelN],cue_mode
- [x] [ChannelN],local_bpm
- [x] [Shoutcast],enabled
- [x] [Shoutcast],status

- [x] Also fixed some typos. @Holzhaus 