### PR TITLE
added more description to Analyze your tracks

### DIFF
--- a/source/chapters/getting_started.rst
+++ b/source/chapters/getting_started.rst
@@ -74,7 +74,7 @@ Analyze your library
    S.Brandt <s.brandt@mixxx.org>
 
 |ic_lib_prepare| Mixxx automatically analyzes tracks the first time you load
-them in a deck. This allows you to run :term:`beatgrid`, :term:`key`, and :term:`ReplayGain` detection on tracks in advance. It also prepares the waveform overviews, detects file corruption, and calculates the BPM values.
+them in a deck. This allows you to run :term:`beatgrid`, :term:`key`, and :term:`ReplayGain` detection on tracks in advance. It also prepares the waveform overviews, detects file corruption, and calculates the :term:`BPM` values.
 
 .. seealso:: For more information, go to :ref:`configuration-bpm-detection`.
 

--- a/source/chapters/getting_started.rst
+++ b/source/chapters/getting_started.rst
@@ -82,7 +82,7 @@ Why you should analyze your audio files
 ---------------------------------------
 
 If the tracks have never been played with Mixxx before, the library columns :guilabel:`BPM`,
-:guilabel:`Duration` and :guilabel:`Key` will be empty.
+:guilabel:`Duration` and :guilabel:`Key` will be empty or unreliable (because the values are just read from the file's tags if present and might be wrong). 
 It is recommended that you analyze your audio files before
 playing live to ensure the beatgrids are correct and these fields show. Furthermore, track
 analysis takes considerable CPU power and might cause skips in the audio ---

--- a/source/chapters/getting_started.rst
+++ b/source/chapters/getting_started.rst
@@ -74,19 +74,31 @@ Analyze your library
    S.Brandt <s.brandt@mixxx.org>
 
 |ic_lib_prepare| Mixxx automatically analyzes tracks the first time you load
-them in a deck, nevertheless it is recommended that you analyze them before
-playing live to ensure the beatgrids are correct. Furthermore, track
+them in a deck. This allows you to run :term:`beatgrid`, :term:`key`, and :term:`ReplayGain` detection on tracks in advance. It also prepares the waveform overviews, detects file corruption, and calculates the BPM values.
+
+.. seealso:: For more information, go to :ref:`configuration-bpm-detection`.
+
+Why you should analyze your audio files
+---------------------------------------
+
+If the tracks have never been played with Mixxx before, the library columns :guilabel:`BPM`,
+:guilabel:`Duration` and :guilabel:`Key` will be empty.
+It is recommended that you analyze your audio files before
+playing live to ensure the beatgrids are correct and these fields show. Furthermore, track
 analysis takes considerable CPU power and might cause skips in the audio ---
 things you surely don't need while performing.
 
-Once you have
-:ref:`imported your music library<getting-started-import-audio-files>`, press
-:guilabel:`OK` on the Preferences window. Go to the Analyze view on the left
-side panel of the library. This allows you to run :term:`beatgrid`,
-:term:`key`, and :term:`ReplayGain` detection on tracks in advance. While
-analyzing, the progress in percentage and total queue length are shown.
+How to analyze your audio files
+-------------------------------
+Once you have :ref:`imported your music library<getting-started-import-audio-files>`, press
+:guilabel:`OK` on the Preferences window.
 
-.. seealso:: For more information, go to :ref:`configuration-bpm-detection`.
+* Go to the :guilabel:`Analyze` view on the left side panel of the library.
+* To analyze a few specific tracks, hold down the :kbd:`Ctrl` button, and select the tracks that you want to analyze. Once they've been highlighted, click the :guilabel:`Analyze` button on the top right of th library section.
+* To analyze the newly added tracks, toggle the :guilabel:`New` label and then click :guilabel:`Analyze`.
+* To analyze the entire library, toggle the :guilabel:`All` label and then click :guilabel:`Analyze`.
+
+While analyzing, the progress in percentage and total queue length are shown.
 
 .. _getting-started-sound-io:
 

--- a/source/chapters/getting_started.rst
+++ b/source/chapters/getting_started.rst
@@ -82,10 +82,10 @@ Why you should analyze your audio files
 ---------------------------------------
 
 If the tracks have never been played with Mixxx before, the library columns :guilabel:`BPM`,
-:guilabel:`Duration` and :guilabel:`Key` will be empty or unreliable (because the values are just read from the file's tags if present and might be wrong). 
-It is recommended that you analyze your audio files before
-playing live to ensure the beatgrids are correct and these fields show. Furthermore, track
-analysis takes considerable CPU power and might cause skips in the audio ---
+:guilabel:`Duration` and :guilabel:`Key` will be empty or unreliable (because the values are just read from the file's tags if present and might be wrong).
+Pre-generating beatgrids gives you the chance to double-check
+the beat markers to make sure they are correct. Errors in beatgrids can cause difficulty when syncing tracks.
+Furthermore, track analysis takes considerable CPU power and might cause skips in the audio ---
 things you surely don't need while performing.
 
 How to analyze your audio files
@@ -94,9 +94,10 @@ Once you have :ref:`imported your music library<getting-started-import-audio-fil
 :guilabel:`OK` on the Preferences window.
 
 * Go to the :guilabel:`Analyze` view on the left side panel of the library.
-* To analyze a few specific tracks, hold down the :kbd:`Ctrl` button, and select the tracks that you want to analyze. Once they've been highlighted, click the :guilabel:`Analyze` button on the top right of th library section.
+* To analyze a few specific tracks, hold down the :kbd:`Ctrl` button, and select the tracks that you want to analyze or you can :kbd:`shift`-select a range of tracks. Once they've been highlighted, click the :guilabel:`Analyze` button on the top right of the library section.
 * To analyze the newly added tracks, toggle the :guilabel:`New` label and then click :guilabel:`Analyze`.
 * To analyze the entire library, toggle the :guilabel:`All` label and then click :guilabel:`Analyze`.
+* The :guilabel:`New` and :guilabel:`All` toggle buttons are located at the top left of the analysis pane - just above the :guilabel:`Preview` and :guilabel:`Cover Art` column titles of the library.
 
 While analyzing, the progress in percentage and total queue length are shown.
 

--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -835,7 +835,7 @@ view, then right-click on a session's name/date to access the different features
 * **Join with previous**: Append the selected history session to the end of the
   previous one.
 * **Export playlist**: Export a session in various file formats. This allows you
-  to use the data in other applications.
+  to use the data in other applic
 
 
 .. _library-analyze:

--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -835,8 +835,7 @@ view, then right-click on a session's name/date to access the different features
 * **Join with previous**: Append the selected history session to the end of the
   previous one.
 * **Export playlist**: Export a session in various file formats. This allows you
-  to use the data in other applic
-
+  to use the data in other applications.
 
 .. _library-analyze:
 


### PR DESCRIPTION
This fixes #350 

The manual never defines what exactly analysis does and why it is important, hence it can easily be overlooked - especially by the new user. It would be great to add why users should do it in advance and what happens if they don't.

@Be-ing @Holzhaus @ywwg please, kindly review :)