### PR TITLE
updated broken link

### DIFF
--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -861,7 +861,7 @@ Supported libraries:
 * |ic_lib_itunes| `iTunes <https://www.apple.com/itunes/>`_ (Windows, macOS)
 * |ic_lib_traktor| `Traktor <https://www.native-instruments.com/en/catalog/traktor/>`_ (Windows, macOS)
 * |ic_lib_rhythmbox| `Rhythmbox <https://wiki.gnome.org/Apps/Rhythmbox>`_ (GNU/Linux)
-* |ic_lib_banshee| `Banshee <http://banshee.fm/>`_ (Windows, macOS, GNU/Linux)
+* |ic_lib_banshee| `Banshee <https://www.banshee-project.org/>`_ (Windows, macOS, GNU/Linux)
 
 The external library views allow you to use music libraries you have created
 in these third-party applications. You can access music as well as playlists. If


### PR DESCRIPTION
What is updated ?
- Broken link of banshee is updated.

new link
https://www.banshee-project.org/

Resolve issue no #365 from manual repository.