### PR TITLE
MixTrackPro3 Hwlabel Refactor

### DIFF
--- a/source/hardware/controllers/numark_mixtrack_pro_3.rst
+++ b/source/hardware/controllers/numark_mixtrack_pro_3.rst
@@ -194,7 +194,7 @@ direction
 | Adjusts the Dry/Wet mix of the deck’s Effect Unit
 | :hwlabel:`TAP` + :hwlabel:`BEATS`: Moves the beat grid left (turn counterclockwise) or
   right (turn clockwise)
-| :hwlabel:`SHIFT` + :hwlabel:`BEATS`: Adjust beatjup amount  
+| :hwlabel:`SHIFT` + :hwlabel:`BEATS`: Adjust beatjup amount
 | :hwlabel:`PADMODE` + :hwlabel:`BEATS`: Adjust Sampler Volume.
   Left beat knob will adjust Samplers 1-4; Right knob will adjust Samplers 5-8
 
@@ -408,5 +408,4 @@ behave as a normal button (ON on first press, OFF on second press)
 30. Master Output LEDs
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Displays the audio level going to the Master Output.
-
+| Displays the audio level going to the Master Output.

--- a/source/hardware/controllers/numark_mixtrack_pro_3.rst
+++ b/source/hardware/controllers/numark_mixtrack_pro_3.rst
@@ -4,6 +4,7 @@ Numark Mixtrack (Pro) 3
 =======================
 
 -  `Manufacturer’s product page <http://www.numark.com/product/mixtrack-pro-3>`__
+-  `Manufacturer's User Manual <https://www.numark.com/images/product_downloads/MixtrackPro3-UserGuide-v1.1.pdf>`__
 -  `Forum thread <https://mixxx.discourse.group/t/mixtrack-pro-3/15165>`__
 
 The Numark Mixtrack 3 and Numark Mixtrack Pro 3 are the same controller
@@ -80,9 +81,9 @@ Mapping Description
 
 | Rotate this knob to cycle through tracks in main library window. Press
   the Knob to expand library view.
-| **Shift + Turn:** allows selecting Play Lists and side navigation bar
+| :hwlabel:`SHIFT` **+ Turn:** allows selecting Play Lists and side navigation bar
   items.
-| **Shift + Push:** opens / closes selected side navigation bar item.
+| :hwlabel:`SHIFT` **+ Push:** opens / closes selected side navigation bar item.
 
 2. Master Gain
 ~~~~~~~~~~~~~~
@@ -108,7 +109,7 @@ Adjusts the volume for headphone cueing in the software.
 
 | Press one of these buttons while a track is selected in the library
   window to assign it to Deck 1 and 2, respectively, in the software.
-| **Shift + Load:** Activates Fader Start mode for the corresponding
+| :hwlabel:`SHIFT` + :hwlabel:`LOAD`: Activates Fader Start mode for the corresponding
   (PFL Button is then blinking). Fader start guide: In fader start mode,
   not only you can press the play/pause button to play/pause the track,
   but if you move up the level fader (the volume fader if you prefer) of
@@ -123,19 +124,19 @@ Adjusts the volume for headphone cueing in the software.
 ~~~~~~~~~~~~~~~~
 
 | Adjust High frequencies of the deck
-| **Shift + High :** Adjust parameter 1 of the currently focused effect on this deck.
+| :hwlabel:`SHIFT` + :hwlabel:`HIGH`: Adjust parameter 1 of the currently focused effect on this deck.
 
 7. Mid EQ Knobs
 ~~~~~~~~~~~~~~~
 
 | Adjust Mid frequencies of the deck
-| **Shift + Mid:** Adjust parameter 2 of the currently focused effect on this deck.
+| :hwlabel:`SHIFT` + :hwlabel:`MID`: Adjust parameter 2 of the currently focused effect on this deck.
 
 8 Low EQ Knobs
 ~~~~~~~~~~~~~~
 
 | Adjust Low frequencies of the deck
-| **Shift + Mid:** Adjust parameter 3 of the currently focused effect on this deck.
+| :hwlabel:`SHIFT` + :hwlabel:`LOW`: Adjust parameter 3 of the currently focused effect on this deck.
 
 9. Filter
 ~~~~~~~~~
@@ -143,16 +144,15 @@ Adjusts the volume for headphone cueing in the software.
 | Adjusts the amount of the filter effect. Turning the knob left
   controls the low pass filter; turning it right controls the high pass
   filter.
-| **Shift + Filter:** Adjust parameter 4 of the currently focused effect on this deck.
+| :hwlabel:`SHIFT` + :hwlabel:`FILTER`: Adjust parameter 4 of the currently focused effect on this deck.
 | If effect is unfocused then;
-| **Shift + Filter:** Adjust the gain of the deck.
+| :hwlabel:`SHIFT` + :hwlabel:`FILTER` Adjust the gain of the deck.
 
 10. Cue/PFL/Headphones
 ~~~~~~~~~~~~~~~~~~~~~~
 
 | Sends pre-fader audio to the headphone output
-| **SHIFT + press:** toggle slip mode
-| **SHIFT + double press**: toggle quantize mode
+| :hwlabel:`SHIFT` + :hwlabel:`CUE/PFL`: Toggle quantize mode
 
 11. Volume fader
 ~~~~~~~~~~~~~~~~
@@ -168,7 +168,8 @@ Controls the blend between the two decks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 | Press and hold to momentarily reduce the speed of the track.
-| **Shift+Pitch Bend Down/Up:** Jump 1 beat backward/forward
+| :hwlabel:`SHIFT` + **PITCH BEND** :hwlabel:`-`/:hwlabel:`+`: Jump 1 beat backward/forward
+|  - If loop is activated, move loop by beatjump amount instead.
 
 15. Pitch Fader
 ~~~~~~~~~~~~~~~
@@ -185,46 +186,44 @@ direction
 | Use the Touch Strip to adjust the deck’s Effect Unit Superknob. If
   Effects are assigned to Instant FX , they will be enabled instantly on
   touch, and disabled on finger lift.
-| **Shift + Touch Strip:** search through a track’s timeline
+| :hwlabel:`SHIFT` + **Touch Strip**: search through a track’s timeline
 
 17. Beats Multiplier
 ~~~~~~~~~~~~~~~~~~~~
 
 | Adjusts the Dry/Wet mix of the deck’s Effect Unit
-| **Shift + Beats:** Moves the beat grid left (turn counterclockwise) or
-  right (turn clockwise) **Padmode + Beats:** Adjust Sampler Volume.
-  Left beat knob will adjusts Samplers 1-4; Right knob will adjusts
-  Samplers 5-8
+| :hwlabel:`TAP` + :hwlabel:`BEATS`: Moves the beat grid left (turn counterclockwise) or
+  right (turn clockwise)
+| :hwlabel:`SHIFT` + :hwlabel:`BEATS`: Adjust beatjup amount  
+| :hwlabel:`PADMODE` + :hwlabel:`BEATS`: Adjust Sampler Volume.
+  Left beat knob will adjust Samplers 1-4; Right knob will adjust Samplers 5-8
 
 18. FX 1 On/Off
 ~~~~~~~~~~~~~~~
 
 | Turns FX1 on and off
-| **Shift + FX 1:** Select from the list of available effects for the respective effect.
-| **Padmode + FX 1:** Assign / unassign FX 1 to Instant FX. When assigned to
-  Instant FX, the FX is instantly activated by touching the Strip and
-  stopped when finger is lifted.
-| **Tap + FX 1:** Focus this effect to allow adjusting its metaknob with the touch strip.
+| :hwlabel:`SHIFT` + :hwlabel:`FX1`: Select from the list of available effects for the respective effect.
+| :hwlabel:`PADMODE` + :hwlabel:`FX1`: Assign / unassign FX 1 to Instant FX. When assigned to
+  Instant FX, the FX is instantly activated by touching the Strip and stopped when finger is lifted.
+| :hwlabel:`TAP` + :hwlabel:`FX1`: Focus this effect to allow adjusting its metaknob with the touch strip.
 
 19. FX 2 On/Off
 ~~~~~~~~~~~~~~~
 
 | Turns FX2 on and off
-| **Shift + FX 2:** Select from the list of available effects for the respective effect.
-| **Padmode + FX 2:** Assign / unassign FX 1 to Instant FX. When assigned to
-  Instant FX, the FX is instantly activated by touching the Strip and
-  stopped when finger is lifted.
-| **Tap + FX 2:** Focus this effect to allow adjusting its metaknob with the touch strip.
+| :hwlabel:`SHIFT` + :hwlabel:`FX2`: Select from the list of available effects for the respective effect.
+| :hwlabel:`PADMODE` + :hwlabel:`FX2`: Assign / unassign FX 1 to Instant FX. When assigned to
+  Instant FX, the FX is instantly activated by touching the Strip and stopped when finger is lifted.
+| :hwlabel:`TAP` + :hwlabel:`FX2`: Focus this effect to allow adjusting its metaknob with the touch strip.
 
 20. FX 3 On/Off
 ~~~~~~~~~~~~~~~
 
 | Turns FX3 on and off
-| **Shift + FX 3:** Select from the list of available effects for the respective effect.
-| **Padmode + FX 3:** Assign / unassign FX 1 to Instant FX. When assigned to
-  Instant FX, the FX is instantly activated by touching the Strip and
-  stopped when finger is lifted.
-| **Tap + FX 3:** Focus this effect to allow adjusting its metaknob with the touch strip.
+| :hwlabel:`SHIFT` + :hwlabel:`FX3`: Select from the list of available effects for the respective effect.
+| :hwlabel:`PADMODE` + :hwlabel:`FX3`: Assign / unassign FX 1 to Instant FX. When assigned to
+  Instant FX, the FX is instantly activated by touching the Strip and stopped when finger is lifted.
+| :hwlabel:`TAP` + :hwlabel:`FX3`: Focus this effect to allow adjusting its metaknob with the touch strip.
 
 21. Tap BPM
 ~~~~~~~~~~~
@@ -232,17 +231,18 @@ direction
 | Press this 8 or more times on beat to manually enter a new BPM. The
   software will ignore the track’s BPM and follow your manually entered
   tempo.
-| **Shift + Tap:** Toggles deck between deck 1-3 (left side) or deck 2-4
+| :hwlabel:`SHIFT` + :hwlabel:`TAP`: Toggles deck between deck 1-3 (left side) or deck 2-4
   (right side). TAP LED will be RED when deck 3 is active (Left Tap) or
   deck 4 is active (Right Tap)
-| **Tap + Hotcue 1:** Activates Brake effect
-| **Tap + Hotcue 2:** Activates Spinback effect
+| :hwlabel:`TAP` + :hwlabel:`HOTCUE 1`: Activates Brake effect
+| :hwlabel:`TAP` + :hwlabel:`HOTCUE 2`: Activates Spinback effect
 
 22. Wheel button
 ~~~~~~~~~~~~~~~~
 
-Activate this button to use the platter/jog wheel to grab and move the
-audio, scratching the track like a vinyl record.
+| Activate this button to use the platter/jog wheel to grab and move the
+  audio, scratching the track like a vinyl record.
+| :hwlabel:`SHIFT` + :hwlabel:`WHEEL`: Toggle slip mode on/off
 
 23. Platter/Jog Wheel
 ~~~~~~~~~~~~~~~~~~~~~
@@ -251,16 +251,15 @@ audio, scratching the track like a vinyl record.
   (always) & Wheel Off - if
   `PitchBendOnWheelOff <#configuration-options>`__ configuration option
   is true) and / track positioning (Wheel On)
-| **Wheel On + Touch platter:** scratching: touch the platter and move
-  it
-| **Shift + Wheel On + Touch platter**: iCut mode: simulates a scratch
+| :hwlabel:`WHEEL` **On** + **Touch platter**: scratching: touch the platter and move it
+| :hwlabel:`WHEEL` **Off** + **Touch platter**: If track is not playing, allows
+  positioning the track
+| :hwlabel:`SHIFT` + :hwlabel:`WHEEL` **Off** + **Touch platter**: fast seek through track
+| :hwlabel:`SHIFT` + :hwlabel:`WHEEL` **On** + **Touch platter**: iCut mode: simulates a scratch
   routine with the jog wheel. When the jog wheel is turned back, the
   crossfader closes; when the jog wheel is turned forward the crossfader
   will open. As a visual reference, TAP LED and Wheel button LED will be
   ON.
-| **Wheel Button Off + Touch platter**: If track is not playing, allows
-  positioning the track
-| **Shift + Wheel Off + Touch platter**: fast seek through track
 
 **Configuration Options:** The `iCutEnabled <#configuration-options>`__
 and `fastSeekEnabled <#configuration-options>`__ options can be used to
@@ -273,10 +272,6 @@ lock on.
 
 | Allows multiple control commands to be triggered when pressed first
   along with other buttons
-| **Single Press** : Temporary SHIFT
-| **Double press** (like a double click): SHIFT Lock enabled (TAP LED
-  will remain ON if Shift Lock is enabled)
-| **Press and release**: toggle off SHIFT Lock if enabled
 
 25. Pad Mode
 ~~~~~~~~~~~~
@@ -301,7 +296,7 @@ Sampler).
   always have their beats lined up. If the Sync Lock was previously
   activated, it just deactivates it regardless of the Short press/Double
   Press
-| **Shift + Sync:** Toggle Key Lock
+| :hwlabel:`SHIFT` + :hwlabel:`SYNC`: Toggle Key Lock
 
 **Configuration Options:** The
 `noPlayOnSyncDoublePress <#configuration-options>`__ option can be used
@@ -311,14 +306,14 @@ to turn off Play on Sync Double Press.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Behavior depends on the :ref:`cue mode <interface-cue-modes>` set in the Mixxx preferences.
-**Shift + Cue:** return the play head to the start of the track.
+| :hwlabel:`SHIFT` + :hwlabel:`CUE`: Return the play head to the start of the track.
 
 28. Play/Pause
 ~~~~~~~~~~~~~~
 
 | Starts and suspends playback. If no track is loaded, loads the
   selected track (if any) and play.
-| **Shift + Play/Pause:** stutter the track from the last set cue point.
+| :hwlabel:`SHIFT` + :hwlabel:`PLAY/PAUSE`: Stutter the track from the last set cue point.
   If a cue point has not been set, the play head will return to the
   start of the track.
 
@@ -334,12 +329,12 @@ subsections below for details about each mode.
   point has not already been set for the loaded track, this control will
   mark the hotcue point. If a hotcue point has already been set, this
   control will jump to it.
-| **Shift + Hot Cue**: Deletes the assigned hotcue point
+| :hwlabel:`SHIFT` + :hwlabel:`HOTCUE`: Deletes the assigned hotcue point
 
 Manual Loop Mode
 ^^^^^^^^^^^^^^^^
 
-Hold Pad Mode and press the pad marked Manual Loop (silkscreened above
+Hold :hwlabel:`PADMODE` and press the pad marked Manual Loop (silkscreened above
 the pad) to assign the lower 4 pads to the functions listed below:
 
 -  **Loop In** – Sets the beginning of a loop: When assigned, the Pad
@@ -349,8 +344,10 @@ the pad) to assign the lower 4 pads to the functions listed below:
 -  **On/Off** – (De)activate the loop. If a loop has not been set, this
    button will have no effect.: When assigned, the Pad LED will light
    blue
--  **Loop x1/2** – Halve the length of the loop. Press Shift + Loop x1/2
+-  **Loop x1/2** – Halve the length of the loop. Press :hwlabel:`SHIFT` + **Loop x1/2**
    to double the length of the loop.
+   x1/2 button is disabled unless the corresponding deck is set to
+   be quantized
 
 Auto Loop Mode
 ^^^^^^^^^^^^^^
@@ -358,16 +355,15 @@ Auto Loop Mode
 | Hold Pad Mode and press the pad marked Autoloop to assign the lower 4
   pads to the functions listed below: When assigned, the respective Pad
   LED will blink Yellow
-| \* **Auto 1** – Sets and starts playback of a 2-beat autoloop.
 
+-  **Auto 1** – Sets and starts playback of a 2-beat autoloop.
 -  **Auto 2** – Sets and starts playback of a 4-beat autoloop.
 -  **Auto 3** – Sets and starts playback of a 8-beat autoloop.
 -  **Auto 4** – Sets and starts playback of a 16-beat autoloop.
-   \* **Shift + Auto 1** – Sets and starts playback of a 1/8-beat
-   autoloop.
--  **Shift + Auto 2** – Sets and starts playback of a 1/4-beat autoloop.
--  **Shift + Auto 3** – Sets and starts playback of a 1/2-beat autoloop.
--  **Shift + Auto 4** – Sets and starts playback of a 1-beat autoloop.
+-  :hwlabel:`SHIFT` **+ Auto 1** – Sets and starts playback of a 1/8-beat autoloop.
+-  :hwlabel:`SHIFT` **+ Auto 2** – Sets and starts playback of a 1/4-beat autoloop.
+-  :hwlabel:`SHIFT` **+ Auto 3** – Sets and starts playback of a 1/2-beat autoloop.
+-  :hwlabel:`SHIFT` **+ Auto 4** – Sets and starts playback of a 1-beat autoloop.
 
 If the pad is held down more than .5 second (Long Press), the Autoloop
 will be disabled once pad is released. On Short Press, the pad will
@@ -394,9 +390,9 @@ Sample Mode
    with the unit Sync activated.
 -  **Deck 2 - Sample 2** – Plays the sample assigned to Sample Pad 6
    with the unit Sync activated.
-   \* **Deck 2 - Sample 3** – Plays the sample assigned to Sample Pad 7
+-  **Deck 2 - Sample 3** – Plays the sample assigned to Sample Pad 7
    with the unit Sync activated.
-   \* **Deck 2 - Sample 4** – Plays the sample assigned to Sample Pad 8
+-  **Deck 2 - Sample 4** – Plays the sample assigned to Sample Pad 8
    with the unit Sync activated.
 
 If the pad is held down more than .5 second (Long Press), the sampler
@@ -407,52 +403,10 @@ behave as a normal button (ON on first press, OFF on second press)
 -  Pressing sample button when sample is already playing goes back to
    cue and plays
 -  Shift + sample to stop sample
--  Eject sample by **Tap + Sample X**
+-  Eject sample by :hwlabel:`TAP` + **Sample X**
 
 30. Master Output LEDs
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Displays the audio level going to the Master Output.
 
-Effects
-^^^^^^^
-
--  Toggle effect with **FX button**
--  Focus effect with **Tap + FX button**
--  Move mapping of InstantFX to **Padmode + FX button**
--  **Shift + High** controls parameter 1 of focused effect
--  **Shift + Mid** controls parameter 2 of focused effect
--  **Shift + Low** controls parameter 3 of focused effect
--  **Shift + Filter** controls parameter 4 of focused effect
-
-If no effects are focused, the super knob of the effect rack is
-controlled by the touch strip. If an effect is focused, the touch strip
-controls the meta knob of the focused effect. If any effects are added
-to InstantFX, they are turned on when the touch strip is activated, and
-off when it is not. While active, the meta knobs associated with effects
-with InstantFX enabled are controlled by the touch strip.
-
-Sampler
-^^^^^^^
-
-Beat jump
-^^^^^^^^^
-
--  Adjust beatjump amount with **Shift + Beats knob**
--  Beatjump with **Shift + Pitch Bend +/-**. If loop is activated, move
-   loop by beatjump amount instead.
-
-.. _manual-loop-mode-1:
-
-Manual Loop Mode
-^^^^^^^^^^^^^^^^
-
-The Loop x1/2 button is disabled unless the corresponding deck is set to
-be quantized
-
-Others
-^^^^^^
-
--  Move slip mode to **Shift + Wheel**
--  Move quantize toggle to **Shift + PFL** (single press)
--  Move beat grid alignment to **Tap + Beats knob**

--- a/source/hardware/controllers/numark_mixtrack_pro_3.rst
+++ b/source/hardware/controllers/numark_mixtrack_pro_3.rst
@@ -194,7 +194,7 @@ direction
 | Adjusts the Dry/Wet mix of the deck’s Effect Unit
 | :hwlabel:`TAP` + :hwlabel:`BEATS`: Moves the beat grid left (turn counterclockwise) or
   right (turn clockwise)
-| :hwlabel:`SHIFT` + :hwlabel:`BEATS`: Adjust beatjup amount
+| :hwlabel:`SHIFT` + :hwlabel:`BEATS`: Adjust beatjump amount
 | :hwlabel:`PADMODE` + :hwlabel:`BEATS`: Adjust Sampler Volume.
   Left beat knob will adjust Samplers 1-4; Right knob will adjust Samplers 5-8
 

--- a/source/hardware/controllers/numark_mixtrack_pro_3.rst
+++ b/source/hardware/controllers/numark_mixtrack_pro_3.rst
@@ -305,7 +305,7 @@ to turn off Play on Sync Double Press.
 27. Cue (Transport Control)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Behavior depends on the :ref:`cue mode <interface-cue-modes>` set in the Mixxx preferences.
+| Behavior depends on the :ref:`cue mode <interface-cue-modes>` set in the Mixxx preferences.
 | :hwlabel:`SHIFT` + :hwlabel:`CUE`: Return the play head to the start of the track.
 
 28. Play/Pause


### PR DESCRIPTION
Refactored the Mixtrack Pro Manual to use hwlabels & cleaned up redundant notes. Looks better imo.
Can we get this in before 2.3

I'll work on a tabular view. My 1st tabular draft looked off and super long.