### PR TITLE
Use sphinx-notfound-page to somewhat fix #395

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ transifex-client
 sphinxcontrib-svg2pdfconverter
 sphinx-rtd-theme==0.5.2
 sphinx-multiversion==0.2.1
+sphinx-notfound-page
 ./sphinx-mixxx

--- a/source/conf.py
+++ b/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx_multiversion",
     "sphinx_mixxx",
+    "notfound.extension",
 ]
 
 todo_include_todos = True
@@ -271,6 +272,8 @@ html_sidebars = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = "Mixxxdoc"
 
+# Set URL prefix for 404 page to the URL this version in English
+notfound_urls_prefix = "/"+version+"/en/"
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
This PR will not fix the issue entirely (see problems below), but is intended as a starting point for further fixes. I am not familiar with sphinx so there may be something I've missed.

In this current state, the language links on the 404 page do not work, and it will always use the English 404 page, but styling and other links should be fixed.