### PR TITLE
Changelog Auto-Updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,14 @@ on:
     branches:
     - "main"
     - "[0-9]+.[0-9]+"
+  repository_dispatch:
+    types: rebuild
 
 jobs:
   build-html:
     name: HTML
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -62,7 +64,7 @@ jobs:
     - name: Install Python dependencies
       run: pip install --upgrade -r requirements.txt
     - name: Set up SSH Agent
-      if: github.event_name == 'push' && env.SSH_PRIVATE_KEY != null
+      if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && env.SSH_PRIVATE_KEY != null
       env:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
@@ -74,15 +76,15 @@ jobs:
         ssh-keyscan "${SSH_HOST}" >> "${HOME}/.ssh/known_hosts"
         echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
     - name: Build PDF manual
-      if: github.event_name != 'push' || env.SSH_AUTH_SOCK == null
+      if: (github.event_name != 'push' || github.event_name != 'repository_dispatch') && env.SSH_AUTH_SOCK == null
       run: |
         sphinx-build -b latex -q -j $(nproc) -Dlatex_engine=xelatex source build
         make -C build LATEXMKOPTS="-f -interaction=nonstopmode -pdf -xelatex" all-pdf
     - name: Build PDF manual in all languages
-      if: github.event_name == 'push' && env.SSH_AUTH_SOCK != null
+      if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && env.SSH_AUTH_SOCK != null
       run: sh build_pdf.sh
     - name: Deploy PDF manuals to download server
-      if: github.event_name == 'push' && env.SSH_AUTH_SOCK != null
+      if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && env.SSH_AUTH_SOCK != null
       run: rsync --verbose --recursive --checksum --times --delay-updates "build/pdf/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/"
       env:
         DESTDIR: public_html/downloads/manual

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,15 @@ on:
 jobs:
   update-changelog:
     name: Update Changelog
+    # This job fetches the `CHANGELOG.md` from the corresponding branch in the
+    # mixxxdj/mixxx repository and uses it to update the `version_history.rst`
+    # file. If the file was changed, the change is committed and a
+    # rebuild/redeployment of the manual is triggered.
+    #
+    # This job is not run on changes to the manual repo. Instead, it's
+    # triggered by a repository dispatch hook that gets triggered by a
+    # corresponding workflow in the mixxxdj/mixxx repository whenever the
+    # CHANGELOG.md is changed.
     runs-on: ubuntu-latest
     steps:
     - name: Event Information

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,46 @@
+name: Changelog
+
+on:
+  repository_dispatch:
+    types: update-changelog
+
+jobs:
+  update-changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+    - name: Event Information
+      run: echo "Event '${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.branch }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python dependencies
+      run: pip install -r requirements-changelog.txt
+    - name: Update Changelog
+      run: tools/update_changelog.py -b "${{ github.event.client_payload.branch }}"
+    - name: Check if changes any changes were made
+      run: echo "GIT_DIRTY=$(git diff --quiet ; printf "%d" "$?")" >> "${GITHUB_ENV}"
+    - uses: EndBug/add-and-commit@v7
+      if: env.GIT_DIRTY != null && env.GIT_DIRTY != '0'
+      with:
+        branch: ${{ github.event.client_payload.branch }}
+        add: "source/chapters/appendix/version_history.rst"
+        message: "appendix/version_history: Update changelog for ${{ github.event.client_payload.branch }} branch"
+        author_name: mixxxbot
+        author_email: bot@mixxx.org
+        push: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Trigger Rebuild
+      uses: peter-evans/repository-dispatch@v1
+      if: env.GIT_DIRTY != null && env.GIT_DIRTY != '0' && env.MIXXXBOT_TOKEN != null
+      with:
+        token: ${{ env.MIXXXBOT_TOKEN }}
+        event-type: rebuild
+      env:
+        MIXXXBOT_TOKEN: ${{ secrets.MIXXXBOT_CHANGELOG_AUTOUPDATER_PAT }}

--- a/requirements-changelog.txt
+++ b/requirements-changelog.txt
@@ -1,0 +1,2 @@
+m2r2
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 sphinx
 sphinx-intl
 graphviz
-m2r2
 markupsafe
-requests
 transifex-client
 sphinxcontrib-svg2pdfconverter
 sphinx-rtd-theme==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 sphinx
 sphinx-intl
 graphviz
+m2r2
 markupsafe
+requests
 transifex-client
 sphinxcontrib-svg2pdfconverter
 sphinx-rtd-theme==0.5.2

--- a/source/chapters/appendix.rst
+++ b/source/chapters/appendix.rst
@@ -11,4 +11,4 @@ Appendix
    appendix/commandline_dev_tools
    appendix/mixxx_controls
    appendix/additional_resources
-   appendix/version_history
+   appendix/changelog

--- a/source/chapters/appendix/changelog.rst
+++ b/source/chapters/appendix/changelog.rst
@@ -1,9 +1,9 @@
 .. include:: /shortcuts.rstext
 
-.. _appendix-version-history:
+.. _appendix-changelog:
 
-Version History
-===============
+Changelog
+=========
 
 2.3.0
 -----

--- a/tools/update_changelog.py
+++ b/tools/update_changelog.py
@@ -42,20 +42,6 @@ def changelog_to_rst(changelog):
         flags=re.MULTILINE | re.IGNORECASE,
     )
 
-    # Ensure that all launchpad issues are hyperlinks
-    changelog = re.sub(
-        r"(?!\[)\blp:?(?P<lpid>\d+)\b(?!\])",
-        r"[lp:\g<lpid>](https://bugs.launchpad.net/mixxx/+bug/\g<lpid>)",
-        changelog,
-    )
-
-    # Ensure that all GitHub PRs are hyperlinks
-    changelog = re.sub(
-        r"(?!\[)#\b(?P<ghid>\d+)\b(?!\])",
-        r"[#\g<ghid>](https://github.com/mixxxdj/mixxx/pull/\g<ghid>)",
-        changelog,
-    )
-
     return TEMPLATE.lstrip().format(content=m2r2.convert(changelog))
 
 

--- a/tools/update_changelog.py
+++ b/tools/update_changelog.py
@@ -23,6 +23,7 @@ TEMPLATE = """
 
 
 def fetch_changelog(branch):
+    """ Fetch CHANGELOG.md from branch of mixxxdj/mixxx repository. """
     r = requests.get(
         "https://raw.githubusercontent.com/mixxxdj/mixxx/"
         f"{branch}/CHANGELOG.md"
@@ -32,6 +33,7 @@ def fetch_changelog(branch):
 
 
 def changelog_to_rst(changelog):
+    """ Convert changelog to RST format used by sphinx. """
     # Replace headline with "Version History"
     changelog = re.sub(
         "^# Changelog$",
@@ -62,9 +64,11 @@ def main(argv=None):
     parser.add_argument("-b", "--branch", required=True)
     args = parser.parse_args(argv)
 
+    # Fetch changelog and convert to RST
     changelog = fetch_changelog(args.branch)
     changelog = changelog_to_rst(changelog)
 
+    # Write changelog to version_history.rst file
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "../source/chapters/appendix/version_history.rst",

--- a/tools/update_changelog.py
+++ b/tools/update_changelog.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import re
 
 import m2r2
 import requests
@@ -13,7 +12,7 @@ TEMPLATE = """
 
 .. include:: /shortcuts.rstext
 
-.. _appendix-version-history:
+.. _appendix-changelog:
 
 {content}
 
@@ -34,14 +33,6 @@ def fetch_changelog(branch):
 
 def changelog_to_rst(changelog):
     """ Convert changelog to RST format used by sphinx. """
-    # Replace headline with "Version History"
-    changelog = re.sub(
-        "^# Changelog$",
-        "# Version History",
-        changelog,
-        flags=re.MULTILINE | re.IGNORECASE,
-    )
-
     return TEMPLATE.lstrip().format(content=m2r2.convert(changelog))
 
 
@@ -54,10 +45,10 @@ def main(argv=None):
     changelog = fetch_changelog(args.branch)
     changelog = changelog_to_rst(changelog)
 
-    # Write changelog to version_history.rst file
+    # Write changelog to changelog.rst file
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
-        "../source/chapters/appendix/version_history.rst",
+        "../source/chapters/appendix/changelog.rst",
     )
     with open(path, mode="w") as fp:
         fp.write(changelog)

--- a/tools/update_changelog.py
+++ b/tools/update_changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+
+import m2r2
+import requests
+
+
+TEMPLATE = """
+.. This is a generated file. Do not edit it manually, because it is updated
+   automatically via tools/update_changelog.py.
+
+.. include:: /shortcuts.rstext
+
+.. _appendix-version-history:
+
+{content}
+
+.. seealso:: For an overview of previous versions, `take a look
+             <https://launchpad.net/mixxx/+series>`_ at the timeline.
+"""
+
+
+def fetch_changelog(branch):
+    r = requests.get(
+        "https://raw.githubusercontent.com/mixxxdj/mixxx/"
+        f"{branch}/CHANGELOG.md"
+    )
+    r.raise_for_status()
+    return r.text
+
+
+def changelog_to_rst(changelog):
+    # Replace headline with "Version History"
+    changelog = re.sub(
+        "^# Changelog$",
+        "# Version History",
+        changelog,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+
+    # Ensure that all launchpad issues are hyperlinks
+    changelog = re.sub(
+        r"(?!\[)\blp:?(?P<lpid>\d+)\b(?!\])",
+        r"[lp:\g<lpid>](https://bugs.launchpad.net/mixxx/+bug/\g<lpid>)",
+        changelog,
+    )
+
+    # Ensure that all GitHub PRs are hyperlinks
+    changelog = re.sub(
+        r"(?!\[)#\b(?P<ghid>\d+)\b(?!\])",
+        r"[#\g<ghid>](https://github.com/mixxxdj/mixxx/pull/\g<ghid>)",
+        changelog,
+    )
+
+    return TEMPLATE.lstrip().format(content=m2r2.convert(changelog))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", "--branch", required=True)
+    args = parser.parse_args(argv)
+
+    changelog = fetch_changelog(args.branch)
+    changelog = changelog_to_rst(changelog)
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "../source/chapters/appendix/version_history.rst",
+    )
+    with open(path, mode="w") as fp:
+        fp.write(changelog)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This already allows automating the changelog updates via repository dispatch. I'll open a corresponding PR on the code repo. Please see the indivial commit messages for details.

To trigger a rebuild automatically, a PAT `REPO_TOKEN` needs to be present in the manual repo's secrets, because the default `GITHUB_TOKEN` doesn't to suffice.