### PR TITLE
Update links to macOS software

### DIFF
--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -171,10 +171,10 @@ Effects via AU Lab on macOS
 On macOS there is a simple and free way to give Mixxx access to the
 collection of AU/VST/MAS plugins that are installed on your system.
 
-* Install the free `Soundflower <https://github.com/RogueAmoeba/Soundflower-Original/releases/>`_,
+* Install the free `SoundflowerBed <https://github.com/anastasiuspernat/SoundflowerBed/releases>`_,
   a system extension for inter-application audio routing.
 * Install the free digital audio mixing application
-  `AU Lab <https://www.apple.com/itunes/mastered-for-itunes/docs/au_lab.zip>`_.
+  `AU Lab <https://www.apple.com/apple-music/apple-digital-masters/docs/au_lab.zip>`_.
 
 .. hint:: macOS 10.15 (Catalina) introduces additional restrictions on running
           non-Apple software. Make sure to grant permission in


### PR DESCRIPTION
**Disclaimer:** I'm not a Mac user, and don't have access to one. So, not only can I not guarantee that the software linked here is _working correctly_, but the links haven't been tested **at all** beyond verifying that they're not 404s and appear to reach the expected tools.

I noticed that some of the links in the "Effects via AU Lab on macOS" section were quite moldy.
1. The SoundFlower link pointed to a repo that hasn't been updated since 2013. The replacement is a newer fork that was at least updated in 2020. It mentions still-supported tool versions when discussing compatibility (as opposed to "XCode 4" or "XCode 5", in the previous repo), so that seems like a win.
2. The AU Lab link pointed to a 404 page, but Apple still has a page on their site (https://www.apple.com/apple-music/apple-digital-masters/) which links to a working download.