### PR TITLE
library docu: remove BPM range hint

### DIFF
--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -232,10 +232,9 @@ Right-clicking on selected tracks in the track list reveals the context menu:
 
     * Allows to change the :term:`BPM` to 50%, 66%, 75%, 133,33%, 150%, or
       200% of the BPM set by Mixxx when :ref:`analyzing <library-analyze>`
-      the tracks. If many of the detected BPM values are incorrect, you might
-      want to adjust the :guilabel:`BPM Range` in the
-      :ref:`Analyzer Settings <configuration-bpm-detection>` and re-run the
-      analysis.
+      the tracks. If many of the detected BPM values are incorrect, you may try
+      other settings in the :ref:`Analyzer Settings <configuration-bpm-detection>`
+      and re-run the analysis.
 
     * **Lock/Unlock BPM**: Locks/Unlocks the :term:`BPM` of selected tracks so
       you can't edit them in the track properties. The |ic_lib_bpm_unlocked|


### PR DESCRIPTION
... as that does not exist anymore in 2.3