### PR TITLE
Appendix: document settings files & folders

### DIFF
--- a/source/chapters/appendix.rst
+++ b/source/chapters/appendix.rst
@@ -10,5 +10,6 @@ Appendix
    appendix/application_shortcuts
    appendix/commandline_dev_tools
    appendix/mixxx_controls
+   appendix/settings_directory
    appendix/additional_resources
    appendix/version_history

--- a/source/chapters/appendix/settings_directory.rst
+++ b/source/chapters/appendix/settings_directory.rst
@@ -1,0 +1,74 @@
+.. include:: /shortcuts.rstext
+
+.. _appendix-settings-files:
+
+The Mixxx Settings Directory
+============================
+
+.. sectionauthor::
+   ronso0 <ronso0@mixxx.org>
+
+The Mixxx settings directory contains all user data and settings of your Mixxx installation.
+
+Location
+--------
+
+**Linux**
+
+    ``~/.mixxx/``
+
+    **Note:** make sure you have "Show hidden files" enabled in your file manager
+    in order to show all dot-files and directories.
+
+**Windows**
+
+    | Vista and up: :file:`%LOCALAPPDATA%\\Mixxx`
+    | XP and below: :file:`%USERPROFILE%\\Local Settings\\Application Data\\Mixxx\\`
+    | Type either of those into the location bar of a Computer or Folder window.
+
+**macOS**
+
+    | Mixxx 2.3: :file:`~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx`
+    | Mixxx 2.2 and earlier: :file:`~/Library/Application Support/Mixxx`
+
+Content
+-------
+
+**analysis**
+    This contains all waveform analysis data. This is used to compose a track's
+    scrolling waveform and track overview. If not existent, this data will be
+    recreated each time a track is loaded into a Mixxx deck. Thus it does not
+    belong to the essential data that needs to be backed up.
+
+**broadcast_profiles**
+    All broadcast profiles you have configured.
+
+**controllers**
+    All controller mappings you stored. This can be downloaded and :ref:`self-built
+    mappings <advanced-controller>`, as well as built-in mappings that you modified in
+    :guilabel:`Preferences` > :guilabel:`Controllers` > :guilabel:`YourController`
+    manually or with the MIDI Wizard.
+
+**effects.xml**
+    The current configuration of the 4 effect units, incl. the state of all controls.
+
+**mixxx.cfg**
+    Everything you configured in the Preferences, deck settings, skin settings,
+    AutoDJ configuration, effect routing etc.
+
+**mixxx.log[.NN]**
+    Log files of the last few Mixxx sessions, with ``mixxx.log`` being the most recent one,
+    followed by ``mixxx.log.1`` etc.
+
+**mixxxdb.sqlite**
+    The Mixxx library database. All track locations, all track metadata, saved cues,
+    loops, colors, playlists, crates, ...
+
+**samplers.xml**
+    Stores tracks currently loaded to sample decks.
+
+**sandbox.cfg**
+    This is used under macOS to track which files Mixxx will have access to
+
+**soundconfig.xml**
+    Sound device configuration from Preferences > Sound Hardware

--- a/source/chapters/getting_started.rst
+++ b/source/chapters/getting_started.rst
@@ -47,8 +47,10 @@ make a backup of your existing settings just in case.
   **GNU/Linux**
     Mixxx settings are in :file:`/home/<username>/.mixxx`
 
-Copy this folder to a backup drive or somewhere else on your system to make a
+Copy this directory to a backup drive or somewhere else on your system to make a
 backup of your settings.
+
+.. seealso:: For detailed descriptions of the settings files, go to :ref:`appendix-settings-files`.
 
 Opening Mixxx
 =============


### PR DESCRIPTION
move the documentation from the wiki to the manual to make it more discoverable.

