### PR TITLE
Behringer BCR2000: Fix download links

### DIFF
--- a/source/hardware/controllers/behringer_bcr2000.rst
+++ b/source/hardware/controllers/behringer_bcr2000.rst
@@ -171,7 +171,7 @@ Overlay
 ^^^^^^^
 Overlay to print on cardboard or paper for lamination:
 
-- `PDF, DIN A4 <../../_static/controllers/behringer_bcr2000_overlay_a4.pdf>`_
-- `PDF, DIN A3 <../../_static/controllers/behringer_bcr2000_overlay_a3.pdf>`_
-- `ODG <../../_static/controllers/behringer_bcr2000_overlay.odg>`_ (LibreOffice)
-- `SVG <../../_static/controllers/behringer_bcr2000_overlay_a3_unlabeled.svg>`_ (without labels)
+- :download:`PDF, DIN A4<../../_static/controllers/behringer_bcr2000_overlay_a4.pdf>`
+- :download:`PDF, DIN A3<../../_static/controllers/behringer_bcr2000_overlay_a3.pdf>`
+- :download:`ODG<../../_static/controllers/behringer_bcr2000_overlay.odg>` (LibreOffice)
+- :download:`SVG<../../_static/controllers/behringer_bcr2000_overlay_a3_unlabeled.svg>` (without labels)


### PR DESCRIPTION
The links to static files work in the netlify preview, but are broken on the official manual because _static is missing.