### PR TITLE
Fix outdated hyperlinks

### DIFF
--- a/source/hardware/controllers/hercules_djcontrol_jogvision.rst
+++ b/source/hardware/controllers/hercules_djcontrol_jogvision.rst
@@ -3,7 +3,7 @@
 Hercules DJControl Jogvision
 ============================
 
--  `Manufacturer's product page <https://www.hercules.com/en-us/product/djcontroljogvision-2old/>`__
+-  `Manufacturer's product page <https://www.hercules.com/en/product/djcontroljogvision/>`__
 -  `Manufacturer's support and downloads page <https://support.hercules.com/en/product/djcontroljogvision-en/>`__
 -  `Forum thread <https://mixxx.discourse.group/t/hercules-djcontrol-jogvision/17839>`__
 

--- a/source/hardware/controllers/pioneer_cdj_850.rst
+++ b/source/hardware/controllers/pioneer_cdj_850.rst
@@ -5,7 +5,7 @@ This is a CD and USB media player that can control Mixxx via USB with
 MIDI or HID. It can also control Mixxx by playing timecode from a CD or
 USB drive and running that signal into Mixxx through a sound card.
 
--  `Manufacturer’s product page <https://www.pioneerdj.com/product/player/cdj-850/black/overview/>`__
+-  `Manufacturer’s product page <https://www.pioneerdj.com/product/player/archive/cdj-850/black/overview/>`__
 
 .. versionadded:: 1.10
    Support for :term:`MIDI` mode.


### PR DESCRIPTION
I was only able to fix two links as all the other errors come from SSL errors, bugs in the linkchecker or HTTP 5xx's. 