### PR TITLE
A&H Xone K2: correct encoder documentation to match mapping

### DIFF
--- a/source/hardware/controllers/allen_heath_xone_k2_k1.rst
+++ b/source/hardware/controllers/allen_heath_xone_k2_k1.rst
@@ -99,9 +99,9 @@ toggles the bottom button grid between a loop layer (amber) and a hotcue
 layer (red). Holding shift then holding the bottom left layer button at
 the same time activates supershift mode.
 
--  Top encoder: gain
+-  Top encoder: jog
 
-   -  shift: jog
+   -  shift: gain
    -  supershift: adjust key
 
 -  Top encoder press: reset gain


### PR DESCRIPTION
https://github.com/mixxxdj/mixxx/blob/2.3/res/controllers/Allen-and-Heath-Xone-K2-scripts.js#L265