### PR TITLE
Traktor S3: Update Button Pads section for new sampler behavior

### DIFF
--- a/source/hardware/controllers/native_instruments_traktor_kontrol_s3.rst
+++ b/source/hardware/controllers/native_instruments_traktor_kontrol_s3.rst
@@ -168,7 +168,8 @@ In Hotcues mode, pressing the number button will set the hotcue if none exists, 
 If you hold :hwlabel:`SHIFT` and press a button, it will clear that hotcue.
 
 In Samplers mode, the buttons on the left side of the controller correspond to Samplers 1-8.
-The buttons on the right side of the controller correspond to Samplers 9-16.
+By default, the buttons on the right side of the controller also correspond to Samplers 1-8.
+If you edit the javascript file and set `TraktorS3.SixteenSamplers = true;`, the samplers on the right-hand deck correspond to Samplers 9-16.
 By default, pressing a number button will activate a sample.
 Pressing the button again will stop sample playback.
 


### PR DESCRIPTION
By default, both sides of the controller launch samplers 1-8