### PR TITLE
sphinx_mixxx: declare safe for parallel reading and writing

### DIFF
--- a/sphinx-mixxx/sphinx_mixxx/setup.py
+++ b/sphinx-mixxx/sphinx_mixxx/setup.py
@@ -23,4 +23,8 @@ def setup(app):
         "",
     )
 
-    return {"version": "0.1"}
+    return {
+        "version": "0.1",
+        "parallel_read_safe": False,
+        "parallel_write_safe": False,
+    }


### PR DESCRIPTION
This should silence the build warning:
```
WARNING: the sphinx_mixxx extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```