### PR TITLE
Increase linkcheck timeout

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -454,5 +454,5 @@ linkcheck_ignore = [
 ]
 
 # Avoid freezing during linkcheck
-linkcheck_timeout = 20
+linkcheck_timeout = 60
 linkcheck_retries = 2


### PR DESCRIPTION
because the linkcheck nearly always fails due to timeout currently
- jsfiddle.net seems to be completly down
- For the archive.org, the timeout increase from 20s to 60s seems to help