### PR TITLE
Fix linkcheck

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,6 +2,7 @@ name: Sphinx
 
 on:
   pull_request:
+  push:
 
 jobs:
   linkcheck:

--- a/source/hardware/controllers/vestax_vci_400.rst
+++ b/source/hardware/controllers/vestax_vci_400.rst
@@ -27,9 +27,10 @@ will continue to work with Linux.
 
 Note that the VCI-400 and VCI-400 Ean Golden Edition are incompatible.
 Their firmwares use different MIDI messages to communicate with the
-computer. Unfortunately, `it is not possible to switch between the
-VCI-400 and VCI-400 Ean Golden Edition
-firmware <http://forum.djtechtools.com/showthread.php?t=64071&p=572022&viewfull=1#post572022>`__.
+computer. Unfortunately, it is not possible to switch between the
+VCI-400 and VCI-400 Ean Golden Edition firmware.
+
+.. Reference: forum(dot)djtechtools(dot)com/showthread.php?t=64071&p=572022&viewfull=1#post572022
 
 Mapping
 -------


### PR DESCRIPTION
This PR:
-Changes a link to the dead DJTechTools forum to a comment with a reference to the source (the forum is not archived by webarchive)
-Enables the execution of build-check and link-check for push events as well. To detect issues like #553