### PR TITLE
add links to Components-JS on related pages

### DIFF
--- a/source/chapters/advanced_topics.rst
+++ b/source/chapters/advanced_topics.rst
@@ -105,7 +105,12 @@ work better with Mixxx (scratching), display a complex LED sequence, or even
 send messages to text displays on the controller.
 
 For more information, go to `<https://github.com/mixxxdj/mixxx/wiki/Midi-Scripting>`_
-and `<https://github.com/mixxxdj/mixxx/wiki/hid_mapping_format>`_.
+and `<https://github.com/mixxxdj/mixxx/wiki/hid_mapping_format>`_
+, as well as the `Comonents-JS library <https://github.com/mixxxdj/mixxx/wiki/Components-JS>`_
+which greatly simplifies mapping, for example effect units and complex behaviour
+like switching deck layers or pad grid modes. Note that this is the preferred way
+of mapping if intended your mapping to be included in Mixxx since Components-JS
+significantly reduces effort for both mapping and reviewing Pull Requests.
 
 .. _advanced-keyboard:
 

--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -45,6 +45,15 @@ that it is either 'ON' (non-zero) or 'OFF' (zero).
    line option), you can view and manually set the state of any control in
    Mixxx by going to :menuselection:`Developer --> Developer Tools`.
 
+.. hint:: Simplify mapping of more complex behaviour
+
+   While simple mappings with just a few buttons, knobs and LEDs can easily
+   be created with the MIDI Wizard and some basic scripting, implementing more
+   complex behaviour like switching deck layers or pad grid modes can be tedious
+   and error-prone. For these cases you can use Mixxx' `Comonents-JS library <https://github.com/mixxxdj/mixxx/wiki/Components-JS>`_
+   which provides building blocks for single controls as well as entire
+   containers like decks and effect units.
+
 .. seealso:: See :ref:`controlindex` for a full list.
 
 

--- a/source/chapters/effects.rst
+++ b/source/chapters/effects.rst
@@ -177,6 +177,12 @@ audience, but this requires a few more steps:
 
 Controller Effects Mapping
 ==========================
+
+.. _controller-effects-mapping-usage:
+
+Usage
+-----
+
 This section describes how to use the standard Mixxx mapping for effects sections on controllers with the typical layout of 4 knobs (or 3 knobs + 1 encoder) and 4 buttons for effects. It allows you to switch between controlling all 3 effects of a chain or controlling each parameter of one effect.
 
 By default, 3 knobs are used for controlling effect metaknobs and the buttons under them toggle each effect on/off. To temporarily toggle an effect on/off, press and hold an effect enable button. The 4th knob is used for the mix (dry/wet) knob of the whole chain. On controllers designed for Serato, the :guilabel:`Beats` encoder is used as the mix knob.
@@ -195,3 +201,11 @@ When the focus button is pressed with shift, it toggles the Effect Unit between 
 To load different effects, hold shift and turn the knob for an effect.
 
 To load chain presets 1-4, press the buttons with shift (new in Mixxx 2.4).
+
+.. _controller-effects-mapping-implementation:
+
+Implementation
+--------------
+
+The described behaviour is implemented with the effect components of the `Components-JS library <https://github.com/mixxxdj/mixxx/wiki/Components-JS>`_ . If you want to create or update a mapping take a look at `Components-JS > Effect Unit <https://github.com/mixxxdj/mixxx/wiki/Components-JS#user-content-effectunit>`_ .
+It provides building blocks for entire units (effect units, decks) or just single controls.


### PR DESCRIPTION
Just to avoid more users go crazy while trying to implement the standard fx mapping with the current mapping/effects documentation.