### PR TITLE
Numark Mixtrack Pro FX: Update documentation for the new Fx knob behaviour 

### DIFF
--- a/source/hardware/controllers/numark_mixtrack_pro_fx.rst
+++ b/source/hardware/controllers/numark_mixtrack_pro_fx.rst
@@ -222,6 +222,7 @@ There are a few configurable values at the top of the script (:file:`Numark-Mixt
 
    '``pitchRanges``', '[0.08, 0.16, 1]', 'For adjusting the range of pitch fader. Pressing :hwlabel:`PITCH RANGE` (:hwlabel:`SHIFT` + :hwlabel:`PITCH BEND -`) cycles through available values. Number of values in the array can be changed without further script modifications. Note that the default (first) pitch range must be also selected independently in Mixxx settings (Settings -> Preferences -> Decks -> Slider range).'
    '``waveformsSynced``', 'true', 'This variable should reflect the corresponding Mixxx option (Settings -> Preferences -> Waveforms -> Synchronize zoom level across all waveforms). This affects waveform summary zooming.'
+   '``fxControlsMeta``', 'false', 'Changes the FX encoder to control the FX 1 Effect 1 meta knob and, when shifted, the FX 2 Effect 1 meta knob.'
    '``jogScratchSensitivity``', '1024', 'Scratching sensitivity'
    '``jogScratchAlpha``', '1', 'For controlling the alpha-beta filter used in scratching'
    '``jogScratchBeta``', '1/32', 'For controlling the alpha-beta filter used in scratching'


### PR DESCRIPTION
https://github.com/mixxxdj/mixxx/pull/11718

The switch allows the FX encoder to control the meta knobs of Effect 1 on FX 1 and FX 2 (when shifted).

https://deploy-preview-569--mixxx-manual.netlify.app/hardware/controllers/numark_mixtrack_pro_fx.html