### PR TITLE
remove slightly insensitive genre filtering example.

### DIFF
--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -407,7 +407,7 @@ Mixxx supports the following filters:
       title: foo
       composer: foo
       comment: foo
-      genre:hip-hop -genre:gangsta
+      genre:hip-hop -genre:country
 
   .. note::
      It doesn't matter if you have space between the colon and the argument


### PR DESCRIPTION
There are racial overtones to the term "gangsta" that I would prefer we just avoid completely.