### PR TITLE
Update DDJ 200 manual link

### DIFF
--- a/source/hardware/controllers/pioneer_ddj_200.rst
+++ b/source/hardware/controllers/pioneer_ddj_200.rst
@@ -19,7 +19,7 @@ Pioneer DDJ-200
 The Pioneer DDJ-200 is a 2 deck USB and Bluetooth DJ controller designed for WeDJ, djay, edjing Mix and Rekordbox.
 
 -  `Manufacturer's Product Page <https://www.pioneerdj.com/en-gb/product/controller/ddj-200/black/overview/>`__
--  `Manufacturer's User Manual <http://docs.pioneerdj.com/Manuals/DDJ_200_DRI1596B_manual/>`__
+-  `Manufacturer's User Manual <https://docs.pioneerdj.com/Manuals/DDJ_200_DRI1596C_manual/>`__
 -  `Manufacturer's Firmware Update <https://www.pioneerdj.com/en/support/software/controller/ddj-200/>`__
 -  `Mixxx User Forum <https://mixxx.discourse.group/t/pioneer-ddj-200-mapping/18259>`__
 


### PR DESCRIPTION
The current link is broken and causes the link check to fail.