### PR TITLE
Update the Akai LPD8 link

### DIFF
--- a/source/hardware/controllers/akai_lpd8.rst
+++ b/source/hardware/controllers/akai_lpd8.rst
@@ -1,7 +1,7 @@
 Akai LPD8
 =========
 
--  `Manufacturer’s product page <https://www.akaipro.com/lpd8-lpd8>`__
+-  `Manufacturer’s product page <https://www.akaipro.com/lpd8>`__
 -  `Forum thread <https://mixxx.discourse.group/t/akai-lpd8-mapping-4-decks-30-hotcues-loops-etc-v2/13064>`__
 
 .. versionadded:: 1.10.1


### PR DESCRIPTION
The previous link was broken and this is where the homepage seems to have moved.