### PR TITLE
Sync Lock: Remove references to Explicit Leader

### DIFF
--- a/source/chapters/djing_with_mixxx.rst
+++ b/source/chapters/djing_with_mixxx.rst
@@ -169,7 +169,7 @@ buttons (available in the LateNight and Deere skins only).
 .. |nbsp| unicode:: 0xA0
    :trim:
 
-|follower| Follower |nbsp| |nbsp| |nbsp| |nbsp| |nbsp| |softleader| Soft Leader |nbsp| |nbsp| |nbsp| |nbsp| |nbsp| |explicitleader| Explicit Leader
+|follower| Follower |nbsp| |nbsp| |nbsp| |nbsp| |nbsp| |softleader| Soft Leader
 
 .. |follower| image:: ../_static/2.4/follower.png
    :width: 124px
@@ -178,10 +178,6 @@ buttons (available in the LateNight and Deere skins only).
 .. |softleader| image:: ../_static/2.4/soft-leader.png
    :width: 124px
    :alt: Sync Leader button as soft leader
-
-.. |explicitleader| image:: ../_static/2.4/explicit-leader.png
-   :width: 124px
-   :alt: Sync Leader button as explicit leader
 
 You can create a variable BPM beat grids for single tracks by using the :guilabel:`Analyze`
 library context menu and :guilabel:`Reanalyze (variable BPM)` command. Alternatively you may
@@ -193,17 +189,16 @@ It's important to note that the track follows the "detected" leader tempo uncond
 even if there are sections with unstable tempos during bridges or in the outro regions where
 the actual played tempo wasn't detected correctly.
 
-If a soft leader deck stops or is silenced, Mixxx automatically selects the next best
-deck as Leader. By clicking the Leader button, you can toggle between Explicit Leader
-and Soft Leader mode. An Explicit leader is sticky, does not automatically move.
+If a soft leader deck stops or is silenced, Mixxx automatically selects the next
+best deck as Leader. By clicking the Leader button, you can choose between Soft
+Leader and Follower mode. A Soft Leader is not sticky, and will automatically
+move if the current leader becomes invalid.
 
 By default the "Sync Lock with Dynamic Tempo" feature is enabled and Mixxx picks the
 first Sync Lock enabled track as Soft Leader, using the tempo from its outro during
 the following transition. If you'd like to use the the tempo from the intro of the next
 track instead, click the Leader (Crown) button of its deck.
-The deck then becomes the explicit leader. Click again on the Leader button and the
-deck becomes Soft-follower and Mixxx is again in charge to move the leader to
-the best deck.
+The deck then becomes the soft leader, and Mixxx will use that deck's tempo instead.
 
 If you'd prefer a steady tempo during transitions like in Mixxx before Version 2.4,
 you may select :guilabel:`Use steady Tempo` for :guilabel:`Sync mode` in the

--- a/source/chapters/djing_with_mixxx.rst
+++ b/source/chapters/djing_with_mixxx.rst
@@ -149,7 +149,7 @@ eject, load, and queue any track with sync lock and it won't interrupt the
 playback of the other decks.  However, changing the rate of a stopped deck will
 change the rate of playing decks.
 
-Syn Lock will also notice if one of your tracks is double the BPM of another
+Sync Lock will also notice if one of your tracks is double the BPM of another
 track and match them correctly.  So if you want to mix a 140 BPM drum & bass
 track with a 70 bpm dubstep track, Sync Lock will make sure they are lined up
 properly.
@@ -199,6 +199,11 @@ first Sync Lock enabled track as Soft Leader, using the tempo from its outro dur
 the following transition. If you'd like to use the the tempo from the intro of the next
 track instead, click the Leader (Crown) button of its deck.
 The deck then becomes the soft leader, and Mixxx will use that deck's tempo instead.
+
+The only case when a stopped deck can be a Leader is if no other deck is
+playing. Once a deck starts playing, Mixxx will pick that as the leader instead.
+If another deck starts playing, then you will be able to pick which one you want
+to be the leader again.
 
 If you'd prefer a steady tempo during transitions like in Mixxx before Version 2.4,
 you may select :guilabel:`Use steady Tempo` for :guilabel:`Sync mode` in the


### PR DESCRIPTION
We've removed this feature due to bugs, but most of the useful functionality is still available See https://github.com/mixxxdj/mixxx/pull/12431