### PR TITLE
Pioneer DDJ-FX4: Add waveform zoom

### DIFF
--- a/source/hardware/controllers/pioneer_ddj_flx4.rst
+++ b/source/hardware/controllers/pioneer_ddj_flx4.rst
@@ -76,6 +76,7 @@ No.       Control                                             Function
 ========  ==================================================  ==========================================
 1         :hwlabel:`LOAD` buttons                             Load track selected in library into deck.
 2         Rotary Selector                                     Press to toggle focus between the library sidebar and associated panels. Turn to move focus up or down.
+2         :hwlabel:`SHIFT` + Rotary Selector                  Turn to zoom parallel waveform.
 ========  ==================================================  ==========================================
 
 Deck sections (p. 15)


### PR DESCRIPTION
According to the [Manual](https://docs.pioneerdj.com/Manuals/DDJ_FLX4_DRI1804A_manual/?page=12), turning the rotary selector while pressing a shift button should zoom the parallel waveform.