### PR TITLE
Korg Kaoss DJ - macOS Monterey note

### DIFF
--- a/source/hardware/controllers/korg_kaoss_dj.rst
+++ b/source/hardware/controllers/korg_kaoss_dj.rst
@@ -7,6 +7,8 @@ Korg Kaoss DJ controller
 -  `Forum thread <https://mixxx.discourse.group/t/korg-kaoss-dj-midi-mapping-help/16093>`__
 -  `Pull request on Github <https://github.com/mixxxdj/mixxx/pull/1509>`__
 
+macOS: Please note that the Korg Kaoss DJ is only supported until `macOS Monterey <https://www.korg.com/download/global/support/os/pdf/mac_compatibilitychart_KORG_en.pdf>`__
+
 .. versionadded:: 2.1
 
 Mapping


### PR DESCRIPTION
Hello,

I noticed the Korg Kaoss DJ was no longer working on macOS. After a bit of research, I found that it wasn't Mixxx, but that it's only supported by Korg until macOS Monterey. Please search for `KAOSS DJ` [here](https://www.korg.com/download/global/support/os/pdf/mac_compatibilitychart_KORG_en.pdf)

The issue was raised here:
https://github.com/mixxxdj/mixxx/issues/13439 

Thanks