### PR TITLE
(fix) controls: fix / update `scratch2`, remove `scratch`

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -2722,7 +2722,9 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],scratch2
                    [SamplerN],scratch2
 
-   Affects absolute play speed & direction whether currently playing or not when :mixxx:coref:`[ChannelN],scratch2_enable` is active. (multiplicative). Use JavaScript ``engine.scratch`` functions to manipulate in controller mappings.
+   Affects absolute play speed & direction whether currently playing or not when :mixxx:coref:`[ChannelN],scratch2_enable` is active. (multiplicative).
+   Use JavaScript functions ``engine.scratchEnable``, ``engine.scratchDisable``,  ``engine.isScratching`` and  ``engine.isScratching`` to manipulate in controller mappings.
+   See the example in the `Mixxx Wiki -> Controller Scripting -> Scratching and jog wheels <https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels>`__ .
 
    :range: -3.0..3.0
    :feedback: Waveform
@@ -4975,17 +4977,16 @@ In the meantime, skins and controller mappings that still use them will keep wor
        Use :mixxx:coref:`[ChannelN],reloop_toggle` instead.
 
 
-.. mixxx:control:: [ChannelN],scratch
-                   [PreviewDeckN],scratch
-                   [SamplerN],scratch
+.. mixxx:control:: [ChannelN],jog
+                   [PreviewDeckN],jog
+                   [SamplerN],jog
 
-    Affects playback speed and direction (`differently whether currently playing or not <https://github.com/mixxxdj/mixxx/issues/5350>`__) (multiplicative).
+    Affects relative playback speed and direction for short instances (additive & is automatically reset to 0).
+    Use it in controller mappings to do pitch-bend with jog wheels. See the example in the `Mixxx Wiki -> Controller Scripting -> Scratching and jog wheels
+    <https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels>`__.
 
     :range: -3.0..3.0
-    :feedback: Waveform
-
-    .. deprecated:: ??
-       Use the JavaScript ``engine.scratch`` functions instead.
+    :feedback: waveform
 
 
 .. mixxx:control:: [ChannelN],filter
@@ -5456,3 +5457,16 @@ These controls have been removed from Mixxx. Skins and controller mappings that 
 
     .. deprecated:: 2.4.0
        This control has been **removed** without a direct replacement. Use the :ref:`effects framework <appendix-mixxxcontrols-effects>` instead.
+
+
+.. mixxx:control:: [ChannelN],scratch
+                   [PreviewDeckN],scratch
+                   [SamplerN],scratch
+
+    Affects playback speed and direction (multiplicative).
+
+    :range: -3.0..3.0
+    :feedback: Waveform
+
+    .. deprecated:: ??
+       Use the JavaScript ``engine.scratch`` functions instead.


### PR DESCRIPTION
Also replaces the (for users) rather useless link to https://github.com/mixxxdj/mixxx/issues/5350 with a link to the jog wheel script example.

Preview:
https://deploy-preview-694--mixxx-manual.netlify.app/chapters/appendix/mixxx_controls#control-[ChannelN]-scratch2

_____
Btw I'm wondering why the gh-wiki-anchors hook insists on changing links
from
https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#scratching-and-jog-wheels
to
https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels