### PR TITLE
update references to `engine.scratch..` functions

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -2442,7 +2442,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],scratch2
                    [SamplerN],scratch2
 
-   Affects absolute play speed & direction whether currently playing or not when :mixxx:coref:`[ChannelN],scratch2_enable` is active. (multiplicative). Use JavaScript ``engine.scratch`` functions to manipulate in controller mappings.
+   Affects absolute play speed & direction whether currently playing or not when :mixxx:coref:`[ChannelN],scratch2_enable` is active. (multiplicative). Use the JavaScript ``engine.scratchTick`` function to manipulate in controller mappings. See the `Scratching and jog wheels <https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels>`__ section for more information.
 
    :range: -3.0..3.0
    :feedback: Waveform
@@ -2454,7 +2454,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],scratch2_enable
                    [SamplerN],scratch2_enable
 
-   Takes over play speed & direction for :mixxx:coref:`[ChannelN],scratch2`.
+   Takes over play speed & direction for :mixxx:coref:`[ChannelN],scratch2`. Use the JavaScript ``engine.scratchEnable``/``engine.scratchDisable`` functions to manipulate in controller mappings. See the `Scratching and jog wheels <https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels>`__ section for more information.
 
    :range: binary
    :feedback: Waveform
@@ -4406,7 +4406,7 @@ In the meantime, skins and controller mappings that still use them will keep wor
     :feedback: Waveform
 
     .. deprecated:: ??
-       Use the JavaScript ``engine.scratch`` functions instead.
+       Use the JavaScript ``engine.scratchTick`` function to manipulate in controller mappings. See the `Scratching and jog wheels <https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#user-content-scratching-and-jog-wheels>`__ section for more information.
 
 
 .. mixxx:control:: [ChannelN],filter


### PR DESCRIPTION
While fixing https://github.com/mixxxdj/mixxx/issues/14000 for me I noticed the scratch controls documentation is incomplete.

Completes the engine scratch function names and adds links to https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#scratching-and-jog-wheels

Furthermore I'd like to clarify if/why the `engine.scratch..` functions should be preferred over `engine.setValue(group, "scratch2..`.
For example `engine.scratchTick(deck, ticks)` vs. `engine.setValue(group, "scratch2", speed)`.
Will start a thread on Zulip soonish.