### PR TITLE
Add new launch option (--start-autodj) to documentation

### DIFF
--- a/source/chapters/appendix/commandline_dev_tools.rst
+++ b/source/chapters/appendix/commandline_dev_tools.rst
@@ -43,6 +43,7 @@ types, go to :ref:`file-format-compatibility`.
 --resource-path PATH            Top-level directory where Mixxx will look for
                                 its resource files such as MIDI mappings,
                                 overriding the default installation location.
+--start-autodj                  Enables Auto DJ when starting Mixxx. 
 --settings-path PATH            Top-level directory where Mixxx will look for
                                 user settings files such as the library database
                                 and preferences configuration file.

--- a/source/chapters/appendix/commandline_dev_tools.rst
+++ b/source/chapters/appendix/commandline_dev_tools.rst
@@ -43,7 +43,7 @@ types, go to :ref:`file-format-compatibility`.
 --resource-path PATH            Top-level directory where Mixxx will look for
                                 its resource files such as MIDI mappings,
                                 overriding the default installation location.
---start-autodj                  Enables Auto DJ when starting Mixxx. 
+--start-autodj                  Enables Auto DJ when starting Mixxx.
 --settings-path PATH            Top-level directory where Mixxx will look for
                                 user settings files such as the library database
                                 and preferences configuration file.


### PR DESCRIPTION
The name of this pull request is pretty descriptive. This adds documentation about the new launch option that was added 2.5 (--start-autodj) 