### PR TITLE
controls: refine `loop_anchor` description, clarify range

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -1792,13 +1792,19 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],loop_anchor
                    [SamplerN],loop_anchor
 
-   Determines whether loops created with :mixxx:coref:`beatloop_activate <[ChannelN],beatloop_activate>` or
-   :mixxx:coref:`beatlooproll_activate <[ChannelN],beatlooproll_activate>` use the current position as loop start or loop end.
+   Adjusts whether loops created with :mixxx:coref:`[ChannelN],beatloop_X_activate`,
+   :mixxx:coref:`[ChannelN],beatloop_X_toggle` or :mixxx:coref:`[ChannelN],beatloop_rX_activate`
+   span forward or backward from the current play position.
 
-   0 for loop start (default), 1 for loop end.
-
-   :range: binary
-   :feedback: Loop anchor button changes state
+   :range:
+     =====  =========
+     Value  Direction
+     =====  =========
+     0      forward
+     -----  ---------
+     1      backward
+     =====  =========
+   :feedback: Loop anchor button
 
    .. versionadded:: 2.5.0
 


### PR DESCRIPTION
`loop_anchor`
`beatloop_rN_toggle`
`beatloop_rN_activate`
`beatlooproll_rN_activate`

added in https://github.com/mixxxdj/mixxx/pull/12745

Closes #715 

Preview: [here](https://deploy-preview-719--mixxx-manual.netlify.app/chapters/appendix/mixxx_controls#control-[ChannelN]-beatloop_rX_activate) and below