### PR TITLE
Pitch slider is no longer opposite to turntable/CDJ behaviour

### DIFF
--- a/source/chapters/user_interface.rst
+++ b/source/chapters/user_interface.rst
@@ -621,10 +621,13 @@ control rate changes also from your computer's keyboard, see the chapter
   :ref:`sync-lock` for more information.
 
 **Pitch/Rate slider**
-  The slider allows you to change the speed of the song, by default up to 10%
-  from the tracks original tempos. The speed will increase as you move the
-  slider up, opposite to the behavior found on DJ turntables and :term:`CDJ`.
-  Right-clicking on the slider will reset the tempo to its original value.
+  The slider allows you to change the speed of the song from the track's
+  original tempo.  In default configuration the speed will increase as you move
+  the slider down, and decrease as you move the slider up (similar to the 
+  behaviour found on DJ turntables and :term:`CDJ` units where moving the 
+  slider towards you increases the speed).  Note that the direction can be
+  inverted, and the range of adjustment widened/narrowed by the settings found
+  under "Decks" in Mixxx's preferences.
 
 **Pitch Rate Display**
   The percent that the track's rate is sped up or slowed down is noted here. Is


### PR DESCRIPTION
The manual states that:
> The slider allows you to change the speed of the song, by default
> up to 10% from the tracks original tempos. The speed will increase
> as you move the slider up, opposite to the behavior found on
> DJ turntables and CDJ

This appears to no longer be the case by default - the "Down increases speed" option under Decks in Preferences appears to be the default setting (and the default range appears to be 8% not 10% as previously documented).

Certainly my Mixxx 2.5.0 wearing the LateNight skin when reset to default preferences (moving `~/.mixxx` aside temporarily) has the "Down increases speed" option selected (and the range set to 8%, not 10% as the manual suggests)

I couldn't find an entry in the changelog to say if/when this changed.