### PR TITLE
Gitignore egg-info generated by pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 source/locale/pot/.doctrees
 /source/locale/en_US
+sphinx-mixxx/sphinx_mixxx.egg-info/


### PR DESCRIPTION
The .egg-info file is generated by PIP when installing Sphinx and other dependencies in a virtual environment. If you are using dependencies from your systems package manager, this file will not be created.

To recreate it, use this common Python workflow to build the manual:

```
$ python -m venv env
$ source env/bin/activate
$ pip install -r requirements.txt # Egg-info stuff will be generated here.
$ make html
```

This is a followup to #728 since it was undecided whether this should be included or not. In its defense, I would note that this is a common byproduct of building Python code and is generated as part of the build process itself (albeit not always, depending on your OS and build setup). It is not eg. something specific to an individual IDE where if you were to gitignore one set of temp files you'd need to do the same for every single developer who used a different system even though they could have just stuck it in their system or local gitignore.

/cc @ronso0, @Holzhaus

**EDIT:** CI failures appear to be unrelated breakage around the Python version.