### PR TITLE
Ci fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-html:
     name: HTML
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.10'
     - name: Install Python dependencies
       run: pip install --upgrade -r requirements.txt
     - name: Build versioned HTML manual
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.10'
     - name: Install Python dependencies
       run: pip install --upgrade -r requirements.txt
     - name: Set up SSH Agent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Deploy to Netlify
       # Increase timeout to 30 minutes because deploying the manual may take
       # a while.
-      run: npx netlify deploy --prod --dir=build/html --timeout 1800
+      run:  |
+        npm install netlify-cli
+        npx netlify deploy --prod --dir=build/html --timeout 1800
       env:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/source/conf.py
+++ b/source/conf.py
@@ -461,6 +461,8 @@ linkcheck_ignore = [
     "https://www.allen-heath.com/ahproducts/*",
     "https://www.allen-heath.com/content/uploads/*",
     "https://www.allen-heath.com/support/",
+    "http://www.keithmcmillen.com/QuNeo/downloads/",
+    "http://www.keithmcmillen.com/products/quneo/",
 ]
 
 # Avoid freezing during linkcheck

--- a/source/conf.py
+++ b/source/conf.py
@@ -461,8 +461,8 @@ linkcheck_ignore = [
     "https://www.allen-heath.com/ahproducts/*",
     "https://www.allen-heath.com/content/uploads/*",
     "https://www.allen-heath.com/support/",
-    "http://www.keithmcmillen.com/QuNeo/downloads/",
-    "http://www.keithmcmillen.com/products/quneo/",
+    "https://www.keithmcmillen.com/QuNeo/downloads/",
+    "https://www.keithmcmillen.com/products/quneo/",
 ]
 
 # Avoid freezing during linkcheck

--- a/source/hardware/controllers/keith_mcmillen_quneo.rst
+++ b/source/hardware/controllers/keith_mcmillen_quneo.rst
@@ -1,7 +1,7 @@
 Keith McMillen QuNeo
 ====================
 
--  `Manufacturer’s product page <http://www.keithmcmillen.com/products/quneo/>`__
+-  `Manufacturer’s product page <https://www.keithmcmillen.com/products/quneo/>`__
 
 Keith McMillen QuNeo is a USB multi purpose pad controller and features
 tactile pads, sliders, rotary sensors and switches. Works with USB, MIDI
@@ -46,7 +46,7 @@ Mapping Description
 The mapping is included with the QuNeo installer, make sure to click the
 “Mixxx” check box when prompted during the installation. Alternatively
 download the Installer from
-`www.keithmcmillen.com <http://www.keithmcmillen.com/QuNeo/downloads/>`__.
+`www.keithmcmillen.com <https://www.keithmcmillen.com/QuNeo/downloads/>`__.
 The MIDI mapping goes with QuNeo’s factory preset number 12. To
 change the factory preset, select the blue MODE button on the device and
 press tab #12. Also see `Youtube - Setting up Mixxx with


### PR DESCRIPTION
This should fix the broken CI. 
This was probably broken since GitHub has updated to ubuntu-latest to 24.04. 
I have pinned now ubuntu-24.04 to do the next runner update as explicit maintenance action. 

I have reported the python issue upstream: 
https://github.com/sphinx-contrib/multiversion/issues/170
@Holzhaus can you have a look? 

A test run can be found here: (still failing because no credentials) 
https://github.com/daschuer/manual/actions/runs/14681823772/job/41205416017

