### PR TITLE
downgrade python to 3.10 because of removed pkg_resources

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: 3.10
     - name: Install Python dependencies
       run: pip install -r requirements-changelog.txt
     - name: Update Changelog


### PR DESCRIPTION
This should fix: 
https://github.com/mixxxdj/manual/actions/runs/14691445517/job/41227287634

Someone fluent in python may migrate the script to Python 3.13 