### PR TITLE
Traktor S3: fix incorrect button description

### DIFF
--- a/source/hardware/controllers/native_instruments_traktor_kontrol_s3.rst
+++ b/source/hardware/controllers/native_instruments_traktor_kontrol_s3.rst
@@ -95,12 +95,12 @@ Decks
 ==========================================  ===========================================================================================================================================================================
 Control                                     Description
 ==========================================  ===========================================================================================================================================================================
-Library encoder press                       Load track selected in library to the deck.
+Library encoder press                       Load track selected in library to the deck or open selected tree in menu.
 :hwlabel:`SHIFT` + Library encoder press    Eject track.
 Small play button                           While held, plays the current track in the preview deck.  If you rotate the library encoder while you hold the :hwlabel:`PLAY` button, Mixxx will scan through the track being previewed.
 Star button                                 This button is not used.
-List-plus button                            Adds the current track to the Auto DJ list.
-:hwlabel:`VIEW` button                      Move focus of library control between left-hand tree and main list.
+:hwlabel:`≡+` (List-plus button)            Move focus of library control between left-hand tree, search, and main list.
+:hwlabel:`VIEW` button                      Expand / minimize library view.
 ==========================================  ===========================================================================================================================================================================
 
 Transport Mode Buttons


### PR DESCRIPTION
Previously the VIEW button said that it selected menus, but it doesn't, it maximizes the library view. The menu / + button next to it toggles between menus.
This also fixes the description of the rotary encoder to explain that it does more than just load tracks.

Related Mixxx PR: mixxxdj/mixxx#14980

Deploy preview: https://deploy-preview-779--mixxx-manual.netlify.app/hardware/controllers/native_instruments_traktor_kontrol_s3.html