### PR TITLE
Glossary changes and link updates

### DIFF
--- a/source/chapters/appendix/additional_resources.rst
+++ b/source/chapters/appendix/additional_resources.rst
@@ -37,10 +37,11 @@ There are a variety of other resources where you can find out more:
   `<https://github.com/mixxxdj/mixxx/issues>`_
 
 * **Mixxx Translations**: To translate Mixxx and promote your mother tongue, go
-  to: `<https://www.transifex.com/mixxx-dj-software/public/>`_. Please
+  to: `<https://explore.transifex.com/mixxx-dj-software/mixxxdj/>`_. Please
   read the `Translation FAQ <https://github.com/mixxxdj/mixxx/wiki/internationalization>`_
   first.
 
 * **Social Media**: Follow us on `Mastodon <https://floss.social/@mixxx>`_,
-  `Twitter <https://twitter.com/mixxxdj>`_, and
-  `Facebook <https://www.facebook.com/pages/Mixxx-DJ-Software/21723485212>`_.
+  `Bluesky <https://bsky.app/profile/mixxx.bsky.social>`_,
+  `Facebook <https://www.facebook.com/pages/Mixxx-DJ-Software/21723485212>`_ and
+  `YouTube <https://www.youtube.com/@mixxxdj/posts>`_

--- a/source/chapters/controlling_mixxx.rst
+++ b/source/chapters/controlling_mixxx.rst
@@ -136,25 +136,27 @@ with a number of mappings for various devices. There are two levels of
 controller mappings:
 
 * **Mixxx Certified Mappings**: These mappings are verified by the Mixxx
-  Development Team.
+  Development Team and are distributed as part of Mixxx itself.
 * **Community Supported Mappings**: These mappings are provided and have been
   verified as working by the Mixxx community, but the Mixxx Development Team is
   unable to verify their quality because we don't have the devices ourselves.
   They might have bugs or rough edges.
 
-If you run into issues with any of these mappings, please file a :term:`bug
-report` on our `Bug Tracker`_ or tell us about it on our mailing list, forums,
-or :term:`IRC` channel. Device support varies for each supported :term:`OS
+If you run into issues with Mixxx Certified Mappings, please file a :term:`bug
+report` on our `Bug Tracker`_.
+
+If you run into issues with Community Supported Mappings please tell the community
+about it on our `Controller mapping forum`_.
+
+Device support varies for each supported :term:`OS
 <operating system>`, so make sure to consult the documentation of the device.
 
 .. hint::  Additional mappings are available in the `Controller mapping forum`_.
 
-.. seealso:: Before purchasing a controller to use with Mixxx, consult our
-             `Hardware Compatibility wiki page`_. It contains the most
-             up-to-date information about which controllers work with Mixxx and
-             the details of each.
+.. seealso:: Before purchasing a controller to use with Mixxx, check our
+             :ref:`Controller List <hardware-manuals>`, that contains all
+             Mixxx Certified Mappings, that are bundled with Mixxx.
 
-.. _Hardware Compatibility wiki page: https://github.com/mixxxdj/mixxx/wiki/Hardware-Compatibility
 .. _Bug Tracker: https://github.com/mixxxdj/mixxx/issues
 .. _Controller mapping forum: https://mixxx.discourse.group/c/controller-mappings/10
 

--- a/source/chapters/getting_involved.rst
+++ b/source/chapters/getting_involved.rst
@@ -26,7 +26,7 @@ As a non-developer
 * Update our `Wiki <https://github.com/mixxxdj/mixxx/wiki>`_ to make sure the
   information on it is up to date.
 * Translate Mixxx using `Transifex
-  <https://www.transifex.com/mixxx-dj-software/public/>`_
+  <https://explore.transifex.com/mixxx-dj-software/mixxxdj/>`_
 * Answer questions on the `Help & Support Forum
   <https://mixxx.discourse.group/c/support/6>`_
 * Help promote Mixxx: If you've got a blog, write an article about Mixxx. Blog

--- a/source/chapters/hardware.rst
+++ b/source/chapters/hardware.rst
@@ -39,10 +39,7 @@ Additionally, you might consider getting the following equiment:
 
 .. seealso:: Instructions how to use DJ Controllers that work
    out-of-the-box with Mixxx can be found in the :ref:`Hardware Manuals
-   <hardware-manuals>` section of this manual.  The `Mixxx DJ Hardware Guide
-   <https://github.com/mixxxdj/mixxx/wiki/Hardware-Compatibility>`_ on the
-   Mixxx Wiki also lists additional devices, including information about their
-   prices, features, and compatibility with Mixxx.
+   <hardware-manuals>` section of this manual.
 
 .. _hardware-controllers:
 

--- a/source/chapters/microphones.rst
+++ b/source/chapters/microphones.rst
@@ -24,7 +24,7 @@ with Mixxx, each with their own pros and cons:
              headphone jack. Also, they can be difficult to configure at the
              same time as a different audio interface for music output.
 
-.. seealso:: The `Mixxx DJ Hardware Guide <https://github.com/mixxxdj/mixxx/wiki/Hardware-Compatibility>`_
+.. seealso:: The `Mixxx DJ Hardware Guide <https://github.com/mixxxdj/mixxx/wiki/Hardware-Compatibility#user-content-usb-audio-interfaces>`_
              lists specific audio interfaces with information about their prices,
              features, and suitability for use with microphones.
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -6,7 +6,12 @@ Glossary of Terms
 
    ASIO
    Audio Stream Input/Output
-     ASIO is a :term:`low-latency <latency>` :term:`audio interface` :term:`API` on Microsoft Windows.
+     Steinbergs ASIO is a third-party :term:`low-latency <latency>` Sound :term:`API`
+     for Microsoft Windows, and is seen the de facto standard for professional audio
+     devices on Windows.
+
+     ASIO shows usually better performance than the Sound APIs of Windows itself,
+     but only when the hardware manufacturer provides a dedicated ASIO driver.
 
    cueing
      Headphone cueing, or just cueing, is listening to the next track you would
@@ -81,13 +86,6 @@ Glossary of Terms
      it and play the track, just like you would put a record on turntable and
      play it.
 
-   IRC
-   Internet Relay Chat
-     IRC is an online chat network. The Mixxx IRC channel
-     was on the `FreeNode IRC Network <https://freenode.net>`_ in the ``#mixxx``
-     channel. The channel was replaced in 2018 by the
-     :term:`Mixxx Zulip Chat <Zulip>`.
-
    Zulip
      `Zulip <https://zulipchat.com/>`_ is a powerful, open source group chat
      application that combines the immediacy of real-time chat with the
@@ -132,6 +130,12 @@ Glossary of Terms
      signals but some controllers use :term:`HID` signals. Many DJs prefer to
      control DJ software using physical knobs, faders, and wheels on controllers
      instead of using a computer keyboard and mouse.
+
+   DVS
+   Digital Vinyl System
+     A system consisting of a traditional turntable, a special vinyl record encoded
+     with a digital :term:`timecode` instead of an analog audio track, an :term:`audio interface`,
+     and a computer running DJ software such as Mixxx that supports :term:`vinyl control` functionality.
 
    vinyl control
      A method of controlling DJ applications which simulates the traditional

--- a/source/hardware/controllers/behringer_ddm4000.rst
+++ b/source/hardware/controllers/behringer_ddm4000.rst
@@ -24,7 +24,7 @@ used either for audio or as MIDI controller:
 The mixer contains no digital interfaces for audio or microphones.
 
 * `Manufacturer's product page <https://www.behringer.com/behringer/product?modelCode=P0167>`_
-* `User Manual <https://mediadl.musictribe.com/media/sys_master/h1f/h4d/8849404887070.pdf>`_
+* `User Manual <https://fast-images.static-thomann.de/pics/atg/atgdata/document/manual/206918_manual.pdf>`_
 * `Forum thread <https://mixxx.discourse.group/t/ddm4000-controller-mapping/20045>`_
 
 .. versionadded:: 2.3


### PR DESCRIPTION
- Added the term DVS to the glossary
- Improved ASIO description in the glossary
- Removed IRC from the glossary
- Replaced references to the outdated controller list in the Wiki
- Improved supported controllers chapter
- Fixed transifex links and adjusted social media links
- Fixed broken DDM4000 manual link