### PR TITLE
pre-commit: ignore unreferenced Hyperlink targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,5 +53,8 @@ repos:
   hooks:
   - id: rstcheck
     name: "Check RST syntax"
+    args: [
+      --ignore-messages=(Hyperlink target.*not referenced)\.$,
+    ]
     additional_dependencies:
     - sphinx


### PR DESCRIPTION
Ignore wrong reports about unreferenced Hyperlink targets - see also https://github.com/rstcheck/rstcheck/issues/77

Sometimes it makes sense to have targets for future referencing included, but even used hyperlink targets are reported as errors. Without this change it is impossible to write or update any documentation - please change this.