### PR TITLE
Add deprecation warnings to TypeScript control types

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -4700,11 +4700,22 @@ The ``[Skin]`` group
    .. versionadded:: 2.6.0
 
 
+Deprecated groups
+~~~~~~~~~~~~~~~~~~~
+
+.. mixxx:controlgroup:: [Samplers]
+
+   The :mixxx:cogroupref:`[Samplers]` group contains controls for showing sampler banks in the :term:`user interface <GUI>` of Mixxx.
+
+   .. deprecated:: 2.4.0
+      Use :mixxx:cogroupref:`[Skin]` instead.
+
 Deprecated controls
 ~~~~~~~~~~~~~~~~~~~
 
 These controls have been deprecated and may be removed in a future version of Mixxx.
 In the meantime, skins and controller mappings that still use them will keep working, but using the suggested alternatives is strongly recommended.
+
 
 .. mixxx:control:: [Master],audio_latency_usage
 

--- a/tools/ts_export_docs_controls.py
+++ b/tools/ts_export_docs_controls.py
@@ -28,6 +28,8 @@ output = manual_dir / "build/mixxx-controls.d.ts"
 class Group:
     name: str
     description: list[str]
+    version_added: str | None
+    deprecated_since: str | None
 
 
 @dataclass
@@ -171,14 +173,14 @@ def get_deprecated(content: nodes.Element) -> str | None:
     if dep_tag:
         return (
             dep_tag.astext().replace("Deprecated since", "").replace("\n", " ")
-        )
+        ).strip()
     return None
 
 
 def get_version_added(content: nodes.Element) -> str | None:
     dep_tag = get_version_modified_tag(content, "type", "versionadded")
     if dep_tag:
-        return dep_tag.astext().replace("\n", " ")
+        return dep_tag.astext().replace("\n", " ").strip()
     return None
 
 
@@ -234,11 +236,16 @@ def is_pot_meter(content: addnodes.desc_content) -> bool:
 
 
 def extract_group_info(desc: addnodes.desc) -> Group:
+    content = next(desc.findall(addnodes.desc_content))
     name: str = next(desc.findall(addnodes.desc_signature))["ids"][0].replace(
         "controlgroup-", ""
     )
-    description: str = next(desc.findall(addnodes.desc_content)).astext()
-    return Group(name, description.split("\n"))
+    return Group(
+        name,
+        text_content(content),
+        get_version_added(content),
+        get_deprecated(content),
+    )
 
 
 def read_group_info(doc: document) -> list[Group]:
@@ -257,7 +264,16 @@ type GroupedControls = dict[str, dict[str, Control]]
 
 
 def ts_group_doc_comment(group: Group) -> list[str]:
-    return comment_lines(group.description)
+    lines = (
+        group.description
+        if len(group.description) > 0
+        else ["(No description)"]
+    )
+    if group.version_added:
+        lines = [*lines, "", f"@since {group.version_added}"]
+    if group.deprecated_since:
+        lines = [*lines, f"@deprecated since {group.deprecated_since}"]
+    return comment_lines(lines)
 
 
 def ts_control_doc_comment(control: Control) -> list[str]:
@@ -454,7 +470,7 @@ def get_group(name: str, groups: list[Group]) -> Group:
     except StopIteration:
         raise Exception(
             f"""\033[91mFound no description for {name} group\033[0m
-Add .. mixxx:cogroupdesc:: {name} to mixxx_controls.rst"""
+Add .. mixxx:controlgroup:: {name} to mixxx_controls.rst"""
         )
 
 
@@ -474,7 +490,7 @@ def export_ts_types(
     # read/write controls
     rw_controls = filter_controls(
         grouped_controls,
-        lambda c: c.deprecated_since is None and not c.is_read_only,
+        lambda c: not c.is_read_only,
     )
     rw_groups = [
         get_group(name, group_info) for name in extract_groups(rw_controls)
@@ -486,21 +502,13 @@ def export_ts_types(
     lines.append("\t\t// Read-only controls")
     ro_controls = filter_controls(
         grouped_controls,
-        lambda c: c.deprecated_since is None and c.is_read_only,
+        lambda c: c.is_read_only,
     )
     ro_groups = [
         get_group(name, group_info) for name in extract_groups(ro_controls)
     ]
     lines.extend(create_group_control_linking(ro_groups, "ReadOnly"))
     lines.extend(create_control_types_str(ro_controls, "ReadOnly"))
-    lines.append("\n\t}\n")
-
-    # deprecated controls
-    lines.append("\tnamespace Deprecated {\n")
-    l_controls = filter_controls(
-        grouped_controls, lambda c: c.deprecated_since is not None
-    )
-    lines.extend(create_control_types_str(l_controls, "Deprecated"))
     lines.append("\n\t}\n")
 
     # Write file


### PR DESCRIPTION
Hi,

just updated the TypeScript control generation and the TS union docs plugin to include controls with deprecation tags. 

Now, if someone uses a deprecated control, they'll see a warning letting them know it's deprecated:

<img width="716" height="116" alt="Bildschirmfoto_20260311_173003" src="https://github.com/user-attachments/assets/b4a4af53-b0d1-4e3c-8392-c9ce02d58990" />


@acolombier This means the next time the controls are updated, Mixxxbot will commit a larger change than usual, just so you aren't surprised.