### PR TITLE
docs: clarify empty field search, add anchor for #754

### DIFF
--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -484,11 +484,16 @@ Mixxx supports the following filters:
 
     ::
 
-       genre:hip-hop -year:1990
 
-  * Search for empty fields. The following example lists all tracks without a
-    genre. It works for all text fields, including crates.
+    genre:hip-hop -year:1990
 
+.. _search-empty-fields:
+
+
+
+* Search for empty fields. The following example lists all tracks without a genre. It works for all text fields.
+
+   
     ::
 
        genre:""

--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -408,6 +408,13 @@ Mixxx supports the following filters:
       comment: foo
       genre:hip-hop -genre:country
 
+             * Search for empty fields. The following example lists all tracks without a genre. It works for all text fields.
+
+
+            ::
+
+             genre:""
+
   .. note::
      It doesn't matter if you have space between the colon and the argument
      or not. Quotes must be used for multi-word text arguments.
@@ -486,17 +493,6 @@ Mixxx supports the following filters:
 
 
     genre:hip-hop -year:1990
-
-.. _search-empty-fields:
-
-
-
-* Search for empty fields. The following example lists all tracks without a genre. It works for all text fields.
-
-   
-    ::
-
-       genre:""
 
 
   Examples


### PR DESCRIPTION
Fix documentation for "Search for empty fields"

- Added anchor for direct navigation to this section
- Removed incorrect mention of crates as text fields
- Clarified that the feature works only for text fields (e.g genre, artist)