### PR TITLE
docs: Detail macOS App Sandbox restrictions

### DIFF
--- a/source/chapters/appendix/settings_directory.rst
+++ b/source/chapters/appendix/settings_directory.rst
@@ -30,6 +30,12 @@ You can navigate to the settings directory location manually as described below.
  | Mixxx 2.3: ``~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx``
  | Mixxx 2.2 and earlier: ``~/Library/Application Support/Mixxx``
 
+.. note:: Due to macOS App Sandbox restrictions, Mixxx cannot automatically access external files
+          or drives (like USBs, or your Music directory). You will need to grant permission manually
+          via a file dialog the first time you access paths outside the sandbox. This permission is
+          saved securely in the container.
+
+
 **Linux**
  | For distribution packages, or Mixxx installed from source:
  | ``~/.mixxx/``
@@ -75,7 +81,12 @@ Content
     Stores tracks currently loaded to sample decks.
 
 **sandbox.cfg**
-    This is used under macOS to track which files Mixxx will have access to
+    This is used under macOS to track which files Mixxx will have access to. Because Mixxx runs
+    inside an App Sandbox on macOS, it cannot automatically access files outside of its container
+    (such as external drives, or the user's Music folder) without explicit permission. When you
+    select a folder or file through a native macOS file dialog, Mixxx safely stores a
+    security-scoped bookmark here so that you do not have to grant permission every time you
+    start Mixxx.
 
 **soundconfig.xml**
     Sound device configuration from Preferences > Sound Hardware


### PR DESCRIPTION
# docs: Detail macOS App Sandbox restrictions

Fixes mixxxdj/mixxx#15080

## Summary

This PR adds missing documentation regarding the macOS App Sandbox behavior to the `The Mixxx Settings Directory` appendix.

As noted in the linked issue, users often struggle with filesystem permissions on macOS because the sandbox prevents Mixxx from automatically accessing files outside of its container (like external USB drives or the user's Music folder).

## Changes

- **macOS Location**: Added a note explicitly mentioning sandbox restrictions and the requirement for manual user permission via native file dialogs.
- **sandbox.cfg**: Expanded the description to explain that this file stores security-scoped bookmarks, which resolve the persistent access for folders/files granted by the user.
