### PR TITLE
(fix) Library: remove 'renamed' from rescan description

### DIFF
--- a/source/chapters/library.rst
+++ b/source/chapters/library.rst
@@ -154,8 +154,7 @@ Tracks - View and edit your whole collection
 
   Rescanning the library will add new files to the library and mark tracks
   as missing if the corresponding file has been deleted. It tries to detect
-  and relocate missing tracks if files have been renamed or moved into another
-  directory.
+  and relocate missing tracks if files have been moved into another directory.
 
   Automatically refreshing the metadata of tracks when files have been modified
   by an external application is not supported, yet. In this case you need to


### PR DESCRIPTION
as pointed out in https://github.com/mixxxdj/mixxx/pull/14507#issuecomment-4194535538

Currently the scanner only [compares filename and duration](https://github.com/mixxxdj/mixxx/blob/01a689c0b4d99cf0db6079d134cfed44aef36c5b/src/library/dao/trackdao.cpp#L1921) of missing and new tracks, so this is misleading.