### PR TITLE
Search: adjust result ranking, push hardware manual hits down

### DIFF
--- a/source/_static/js/search-scorer.js
+++ b/source/_static/js/search-scorer.js
@@ -1,0 +1,48 @@
+/**
+ * Adjust Sphinx Search Scoring
+ * This script overrides the default Sphinx scoring to de-prioritize hardware manuals
+ * and control documentation.
+ *
+ * https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_search_scorer
+ *
+ * Priorities:
+ * 0 chapters/
+ * 1 chapters/appendix
+ * 2 hardware manuals
+ */
+var Scorer = {
+    score: result => {
+        const [docName, title, anchor, descr, score, filename] = result;
+        let adjustedScore = score;
+        if (docName.includes('hardware/')) {
+            adjustedScore -= 100;
+        } else if (docName.includes('chapters/appendix/')) {
+            adjustedScore += 50;
+        } else { // docName.includes('chapters/')
+            adjustedScore += 100;
+        }
+        return adjustedScore;
+    },
+
+    // Standard Sphinx weights
+    // query matches the full name of an object
+    objNameMatch: 11,
+    // or matches in the last dotted part of the object name
+    objPartialMatch: 6,
+    // Additive scores depending on the priority of the object
+    objPrio: {
+      0: 15, // used to be importantResults
+      1: 5, // used to be objectResults
+      2: -5, // used to be unimportantResults
+    },
+    //  Used when the priority is not in the mapping.
+    objPrioDefault: 0,
+
+    // query found in title
+    title: 15,
+    partialTitle: 7,
+
+    // query found in terms
+    term: 5,
+    partialTerm: 2,
+};

--- a/source/conf.py
+++ b/source/conf.py
@@ -210,6 +210,7 @@ html_css_files = [
 ]
 
 html_js_files = [
+    "js/search-scorer.js",
     "js/widget-sidebar.js",
 ]
 


### PR DESCRIPTION
This aims to improve the ranking when searching the manual.
Currently, when you search for `gain`, a lot of hardware manuals are at the top -- very likely not what the user wants to see.

New priorities are
0 chapters/
1 chapters/appendix/
2 hardware/

### before:
https://manual.mixxx.org/2.5/en/search.html?q=gain&check_keywords=yes&area=default

### this PR:
https://deploy-preview-873--mixxx-manual.netlify.app/search.html?q=gain&check_keywords=yes&area=default


___
disclaimer: created the inject/override with an agent, so bare with me when it comes to js nitpicking ; )