### PR TITLE
Typo: Remove an extra "the"

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -609,7 +609,7 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
                    [PreviewDeckN],beat_distance
                    [SamplerN],beat_distance
 
-   Outputs the relative position of the play marker in the section between the the previous and next beat marker.
+   Outputs the relative position of the play marker in the section between the previous and next beat marker.
 
    :range: 0.0 - 1.0, real-valued
    :feedback: None


### PR DESCRIPTION
Remove an extra "the"