### PR TITLE
Fix most dead links in controller mappings

### DIFF
--- a/source/hardware/controllers/akai_lpd8.rst
+++ b/source/hardware/controllers/akai_lpd8.rst
@@ -1,7 +1,7 @@
 Akai LPD8
 =========
 
--  `Manufacturer’s product page <https://www.akaipro.com/lpd8>`__
+-  `Manufacturer’s product page <https://www.akaipro.com/downloads-and-support/downloads/?product=LPD8&legacy=true>`__
 -  `Forum thread <https://mixxx.discourse.group/t/akai-lpd8-mapping-4-decks-30-hotcues-loops-etc-v2/13064>`__
 
 .. versionadded:: 1.10.1

--- a/source/hardware/controllers/akai_mpd24.rst
+++ b/source/hardware/controllers/akai_mpd24.rst
@@ -1,7 +1,7 @@
 Akai MPD24
 ==========
 
--  `Manufacturer’s product page <https://www.akaipro.com/mpd24>`__
+-  `Manufacturer’s product page <https://www.akaipro.com/downloads-and-support/downloads/?product=MPD24&legacy=true>`__
 -  `Forum thread <https://mixxx.discourse.group/t/akai-mpd24-midi-setup/9020>`__
 
 .. versionadded:: 1.8

--- a/source/hardware/controllers/american_audio_radius_2000.rst
+++ b/source/hardware/controllers/american_audio_radius_2000.rst
@@ -5,7 +5,7 @@ A CD and USB media player that can control Mixxx over USB with MIDI. It
 can also play timecode from CDs or USB drives which can control Mixxx
 when they are connected by a sound card.
 
--  `Manufacturer’s product page <https://www.americandj.eu/en/radius-2000.html>`__
+-  `Manufacturer’s product page <https://www.adj.eu/radius-2000>`__
 
 .. versionadded:: 1.10
 

--- a/source/hardware/controllers/american_audio_vms2.rst
+++ b/source/hardware/controllers/american_audio_vms2.rst
@@ -10,7 +10,7 @@ can also be used as a stand-alone mixer with analog sources without a
 computer by setting the USB/Analog switches on the front of the device
 to “Analog”.
 
--  `Manufacturer’s product page <http://www.americandj.eu/en/vms2.html>`__, provides manual and drivers for download.
+-  `Manufacturer’s product page <https://www.adj.eu/vms2>`__, provides manual and drivers for download.
 -  `Forum thread <https://mixxx.discourse.group/t/american-audio-vms2/12000>`__, for discussion of mapping options.
 -  `Pull Request <https://github.com/mixxxdj/mixxx/pull/876>`__, which this wiki page describes.
 

--- a/source/hardware/controllers/arturia_keylab_mk1.rst
+++ b/source/hardware/controllers/arturia_keylab_mk1.rst
@@ -1,7 +1,7 @@
 Arturia KeyLab Mk 1
 ===================
 
-`Manufacturer's product page <https://www.arturia.com/keylab88/resources>`_ ·
+`Manufacturer's product page <https://www.arturia.com/support/downloads-manuals/product/keylab88>`_ ·
 `Forum thread <https://mixxx.discourse.group/t/arturia-keylab-mk1/31080>`_
 
 .. versionadded:: 2.5.1

--- a/source/hardware/controllers/behringer_bcd2000.rst
+++ b/source/hardware/controllers/behringer_bcd2000.rst
@@ -7,7 +7,7 @@ The Behringer B-Control Deejay BCD2000 features a USB 4-channel audio interface 
 
 This controller has been discontinued. The :ref:`Behringer BCD3000<behringer-bcd3000>` is its successor.
 
-  - `Manufacturer's product page <https://www.behringer.com/behringer/product?modelCode=P0234>`__
+  - `Manufacturer's product page <https://www.behringer.com/en/products/0700-aaa>`__
   - `Forum thread <https://mixxx.discourse.group/t/behringer-bcd-2000-controller-mapping/12310>`__
 
 .. versionadded:: 1.11

--- a/source/hardware/controllers/behringer_bcd3000.rst
+++ b/source/hardware/controllers/behringer_bcd3000.rst
@@ -3,7 +3,7 @@
 Behringer BCD3000
 =================
 
-  - `Manufacturer's page <https://www.behringer.com/product.html?modelCode=P0758>`__
+  - `Manufacturer's page <https://www.behringer.com/en/products/0700-aab>`__
 
 The B-Control Deejay BCD3000 controller is a 4-channel audio interface.
 It offers a fully fitted controller console with 24-bit A/D und D/A converters,

--- a/source/hardware/controllers/behringer_bcr2000.rst
+++ b/source/hardware/controllers/behringer_bcr2000.rst
@@ -12,7 +12,7 @@ Behringer BCR2000
 
    Behringer BCR2000 (schematic view)
 
-- `Manufacturer's product page <https://www.behringer.com/behringer/product?modelCode=P0245>`_
+- `Manufacturer's product page <https://www.behringer.com/en/products/0808-aaa>`_
 - `Forum thread <https://mixxx.discourse.group/t/behringer-b-control-bcr2000/20287>`_
 
 The B-CONTROL BCR2000 is a general-purpose :term:`USB` :term:`MIDI` controller containing 20

--- a/source/hardware/controllers/behringer_cmd_micro.rst
+++ b/source/hardware/controllers/behringer_cmd_micro.rst
@@ -14,7 +14,7 @@ The *Behringer CMD Micro* is a simple controller for basic two-channel
 mixing. This device does not have a built in sound card, so it would
 require a :ref:`splitter cable <hardware-splitter-cables>` or :ref:`separate audio interface <hardware-audio-interfaces>` to be able to preview tracks in headphones.
 
--  `Manufacturer’s product page <https://www.behringer.com/product.html?modelCode=P0AJR>`__
+-  `Manufacturer’s product page <https://www.behringer.com/en/products/0700-aai>`__
 
 .. versionadded:: 2.1
 

--- a/source/hardware/controllers/behringer_cmd_mm_1.rst
+++ b/source/hardware/controllers/behringer_cmd_mm_1.rst
@@ -10,7 +10,7 @@ DV-1 are designed to be used together with the
 CMD MM-1, but the CMD MM-1 can be used alone or with other controllers
 (especially the :ref:`Novation Launchpad <novation-launchpad-mk2>`).
 
--  `Manufacturer's product page <https://www.behringer.com/product.html?modelCode=P0AJE>`__
+-  `Manufacturer's product page <https://www.behringer.com/en/products/0700-aae>`__
 -  `Forum thread <https://mixxx.discourse.group/t/advanced-behringer-cmd-mm-1-mapping/16753>`__
 
 .. versionadded:: 2.1

--- a/source/hardware/controllers/behringer_cmd_studio_4a.rst
+++ b/source/hardware/controllers/behringer_cmd_studio_4a.rst
@@ -5,7 +5,7 @@ The Behringer CMD STUDIO 4a is a 2 deck controller that supports 4
 virtual decks and has a built in 4 channel (one stereo main, one
 stereo headphones) USB sound card built in.
 
--  `Manufacturer’s product page <https://www.behringer.com/product.html?modelCode=P0809>`__
+-  `Manufacturer’s product page <https://www.behringer.com/en/products/0700-aac>`__
 -  `Mixxx Forum Thread <https://mixxx.discourse.group/t/new-behringer-cmd-studio-4a-mapping/15604>`__
 
 .. versionadded:: 2.1

--- a/source/hardware/controllers/behringer_ddm4000.rst
+++ b/source/hardware/controllers/behringer_ddm4000.rst
@@ -23,7 +23,7 @@ used either for audio or as MIDI controller:
 
 The mixer contains no digital interfaces for audio or microphones.
 
-* `Manufacturer's product page <https://www.behringer.com/behringer/product?modelCode=P0167>`_
+* `Manufacturer's product page <https://www.behringer.com/en/products/0701-aak>`_
 * `User Manual <https://fast-images.static-thomann.de/pics/atg/atgdata/document/manual/206918_manual.pdf>`_
 * `Forum thread <https://mixxx.discourse.group/t/ddm4000-controller-mapping/20045>`_
 

--- a/source/hardware/controllers/denon_mc4000.rst
+++ b/source/hardware/controllers/denon_mc4000.rst
@@ -8,7 +8,7 @@ wheels, performers get access to dedicated hot cue and sample pads for
 on-the-fly remixes.
 
 -  `Manufacturer’s product page <https://www.denondj.com/mc4000-mc4000xus>`__
--  `Manual / Midi commands <http://denon-dj.de/wp-content/uploads/2023/03/MC4000-User-Guide-v1.2_00.pdf>`__
+-  `Manual / Midi commands <https://cdn.inmusicbrands.com/denondj/MC4000/MC4000-User-Guide-v1.2_00.pdf>`__
 -  `Forum thread <https://mixxx.discourse.group/t/denon-mc4000-mapping/15311>`__
 
 The microphone and auxiliary inputs are mixed with the main output in

--- a/source/hardware/controllers/mvave_smc_mixer.rst
+++ b/source/hardware/controllers/mvave_smc_mixer.rst
@@ -1,7 +1,7 @@
 M-Vave SMC-Mixer
 ================
 
-`Manufacturer's product page <https://www.cuvave.com/productinfo/1106102.html>`_ ·
+`Manufacturer's product page <https://web.archive.org/web/20260307145916/https://www.cuvave.com/productinfo/1106102.html>`_ ·
 `Forum thread <https://mixxx.discourse.group/t/m-wave-sinco-smc-mixer-radio-broadcast-mapping/30366>`_
 
 .. versionadded:: 2.5.1

--- a/source/hardware/controllers/mvave_smk-25-ii.rst
+++ b/source/hardware/controllers/mvave_smk-25-ii.rst
@@ -1,7 +1,7 @@
 M-Vave SMK-25 II
 ================
 
-`Manufacturer's product page <https://www.cuvave.com/productinfo/1106099.html>`_ ·
+`Manufacturer's product page <https://web.archive.org/web/20260307143106/https://www.cuvave.com/productinfo/1106099.html>`_ ·
 `Forum thread <https://mixxx.discourse.group/t/sinco-m-vave-smk-25-ii/31350>`_
 
 .. versionadded:: 2.5.1

--- a/source/hardware/controllers/numark_omni_control.rst
+++ b/source/hardware/controllers/numark_omni_control.rst
@@ -1,7 +1,7 @@
 Numark Omni Control
 ===================
 
--  `Manfacturer’s product page <http://www.numark.com/product/omnicontrol>`__
+-  `Manfacturer’s product page <https://web.archive.org/web/20251116215741/https://www.numark.com/product/omnicontrol>`__
 
 .. versionadded:: 1.10
 


### PR DESCRIPTION
Some controller mapping have dead link, I replaced them with their current counterparts. 

For some, the official website is not available anymore, I replaced them with the internet archive version instead, as it was done for other mappings

I hope this helps!