### PR TITLE
Traktor Kontrol S3: Update functionality of Star button in documentation

### DIFF
--- a/source/hardware/controllers/native_instruments_traktor_kontrol_s3.md
+++ b/source/hardware/controllers/native_instruments_traktor_kontrol_s3.md
@@ -97,7 +97,7 @@ you see clipping indicated, lower the gain of the playing decks or use {hwlabel}
 | Library encoder press                      |  Load track selected in library to the deck or open selected tree in menu. |
 | {hwlabel}`SHIFT` + Library encoder press   |  Eject track. |
 | Small play button                          |  While held, plays the current track in the preview deck.  If you rotate the library encoder while you hold the {hwlabel}`PLAY` button, Mixxx will scan through the track being previewed. |
-| Star button                                |  This button is not used. |
+| Star button                                |  Sort the library based on the selected column. Press again to toggle sort order ascending/descending. |
 | {hwlabel}`≡+` (List-plus button)           |  Move focus of library control between left-hand tree, search, and main list. |
 | {hwlabel}`VIEW` button                     |  Expand / minimize library view. |
 


### PR DESCRIPTION
This is based on a PR I just submitted on main : https://github.com/mixxxdj/mixxx/pull/16442