### PR TITLE
Docs: Add [Waveform],stem_split_tracks control (fixes #16825)

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -4745,6 +4745,9 @@ The ``[Waveform]`` group
 
    The :mixxx:cogroupref:`[Waveform]` group contains controls that affect waveform rendering and visualization settings.
 
+.. seealso::
+   For per-deck waveform zoom controls, see :mixxx:coref:`[ChannelN],waveform_zoom`.
+
 .. mixxx:control:: [Waveform],stem_split_tracks
 
    Toggles between stacked (split tracks) and overlapping stem waveform display modes.

--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -4738,6 +4738,29 @@ Controls
    The :mixxx:coref:`[EffectRack1],show` control can be used to show and hide the effect section in the GUI.
 
 
+The ``[Waveform]`` group
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. mixxx:controlgroup:: [Waveform]
+
+   The :mixxx:cogroupref:`[Waveform]` group contains controls that affect waveform rendering and visualization settings.
+
+.. mixxx:control:: [Waveform],stem_split_tracks
+
+   Toggles between stacked (split tracks) and overlapping stem waveform display modes.
+
+   :range:
+      ===== ===================================
+      Value Meaning
+      ===== ===================================
+      0     Overlapping stem waveforms (default)
+      1     Stacked (split) stem waveforms
+      ===== ===================================
+   :feedback: Waveform overview and scrolling display mode changes.
+
+   .. versionadded:: 2.6.0
+
+
 The ``[Skin]`` group
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Summary
This PR adds documentation for the new `[Waveform],stem_split_tracks` ControlObject (CO) that was introduced in mixxxdj/mixxx#16756 for Mixxx 2.6.

### Changes Done
* **`[Waveform]` Control Group:** 
  Created a dedicated section for the `[Waveform]` control group in `mixxx_controls.rst` to categorize waveform rendering and visualization settings.
* **Documented `[Waveform],stem_split_tracks`:**
  * **Functionality:** Explains the control's role in switching between stacked (split tracks) and overlapping stem waveforms.
  * **Values & Range:** Detailed the binary values (`0` for default overlapping display, `1` for stacked/split stem tracks).
  * **Feedback & Behavior:** Noted that changing the control triggers an immediate visual update in both the overview and scrolling waveform renderers.
  * **Version Tagging:** Added the `.. versionadded:: 2.6.0` Sphinx directive

### References
* Fixes #16825
* Related PR: mixxxdj/mixxx#16756

### Rendered Preview
<img width="1108" height="853" alt="Screenshot 2026-08-21 at 11 17 58 PM" src="https://github.com/user-attachments/assets/04e15053-0d29-42cd-97e2-59284aa75b9e" />
clean image matching UI and alignement of the whole page
