### PR TITLE
Reloop Digital Jockey 2 ME: document Linux driver and mapping

### DIFF
--- a/source/hardware/controllers/reloop_digital_jockey_2_master_edition.rst
+++ b/source/hardware/controllers/reloop_digital_jockey_2_master_edition.rst
@@ -74,9 +74,13 @@ In addition, this mapping uses two front panel controls that the
     ==============================  ==========================================
     Control                         Mapped to
     ==============================  ==========================================
-    :hwlabel:`CROSS-FADER CURVE`    :mixxx:coref:`[Mixer Profile],xFaderCurve`
-    :hwlabel:`MIC-LEVEL`            :mixxx:coref:`[Microphone],pregain`
+    :hwlabel:`CROSS-FADER CURVE`    ``[Mixer Profile],xFaderCurve``
+    :hwlabel:`MIC-LEVEL`            :mixxx:coref:`[Microphone] <[MicrophoneN],pregain>`
     ==============================  ==========================================
+
+.. note::
+   :guilabel:`xFaderCurve` sets the crossfader contour and is not documented
+   as a :term:`ControlObject` elsewhere in this manual.
 
 .. note::
    :hwlabel:`PHONE-TONE` and :hwlabel:`MIC-TONE` are intentionally not

--- a/source/hardware/controllers/reloop_digital_jockey_2_master_edition.rst
+++ b/source/hardware/controllers/reloop_digital_jockey_2_master_edition.rst
@@ -1,17 +1,84 @@
+.. _reloop_digital_jockey_2_master_edition:
+
 Reloop Digital Jockey 2 Master Edition
 ======================================
 
--  `Manufacturer’s product page <http://www.reloop.com/reloop-digital-jockey-2-me>`__
+The *Reloop Digital Jockey 2 Master Edition* is a 2 deck USB MIDI controller
+with an integrated 24 bit audio interface and a full analogue mixer section.
+Compared to the *Interface Edition* it adds balanced master outputs, a booth
+output, phono/line inputs with RIAA preamps and a microphone input, so it can
+also be used as a stand-alone mixer without a computer.
+
+-  `Manufacturer's product page <http://www.reloop.com/reloop-digital-jockey-2-me>`__
 -  `Forum thread <https://mixxx.discourse.group/t/help-reloop-digital-jockey-2-master-edition/12583>`__
 
 .. versionadded:: 1.8
 
-.. warning::
-   This device is not USB :term:`MIDI` class compliant.
-   Its signals are translated to :term:`MIDI` by special drivers on Windows and macOS.
-   There is no driver available for Linux.
+.. important::
+   This device is **not** USB :term:`MIDI` class compliant. Its signals are
+   translated to :term:`MIDI` by a vendor driver, so a driver must be
+   installed before Mixxx sees the controller or its audio interface.
+
+   * **Windows and macOS** — use the driver from the manufacturer's product
+     page linked above.
+   * **GNU/Linux** — no vendor driver exists. Use the community driver
+     `snd-usb-ozzy <https://github.com/julled/Ozzy-reloop>`__, an ALSA kernel
+     module that provides audio and MIDI for this controller
+     (`upstream pull request <https://github.com/mischa85/Ozzy/pull/80>`__).
+     Without it the device enumerates as a vendor-specific USB device and
+     neither the MIDI controls nor the sound card are available.
+
+Compatibility
+-------------
+
+Once the driver is installed the controller registers as a normal sound card
+with a MIDI port, and works on Windows, macOS and GNU/Linux.
 
 .. note::
-   Unfortunately a detailed description of this controller mapping is still missing.
-   If you own this controller, please consider
-   `contributing one <https://github.com/mixxxdj/mixxx/wiki/Contributing-Mappings#user-content-documenting-the-mapping>`__.
+   Set the :hwlabel:`MIDI/PHONO/LINE` switch on the front panel to
+   :hwlabel:`MIDI` for the channel you want to control from Mixxx. In the
+   :hwlabel:`PHONO`/:hwlabel:`LINE` position that channel's gain, EQ and line
+   fader stay in the analogue signal path and send no MIDI, so those controls
+   appear dead in Mixxx while the buttons still work.
+
+Mixxx Sound Hardware Preferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The audio interface runs at 44.1 kHz. Its inputs are assigned as follows:
+
+.. table::
+    :widths: 100 100
+
+    ========================  =======================
+    Input                     Channels
+    ========================  =======================
+    :guilabel:`Line In 1`     Channel 1 - 2
+    :guilabel:`Line In 2`     Channel 3 - 4
+    :guilabel:`Microphone`    Channel 5 - 6
+    ========================  =======================
+
+Mapping
+-------
+
+The controller shares its :term:`MIDI` layout with the
+:ref:`Interface Edition <reloop_digital_jockey_2_interface_edition>`, and the
+mapping follows that description, including the jog wheel modes, the
+:hwlabel:`CUP` button behaviour and the :hwlabel:`SHIFT` layer.
+
+In addition, this mapping uses two front panel controls that the
+*Interface Edition* does not have:
+
+.. table::
+    :widths: 40 60
+
+    ==============================  ==========================================
+    Control                         Mapped to
+    ==============================  ==========================================
+    :hwlabel:`CROSS-FADER CURVE`    :mixxx:coref:`[Mixer Profile],xFaderCurve`
+    :hwlabel:`MIC-LEVEL`            :mixxx:coref:`[Microphone],pregain`
+    ==============================  ==========================================
+
+.. note::
+   :hwlabel:`PHONE-TONE` and :hwlabel:`MIC-TONE` are intentionally not
+   mapped. They shape the analogue headphone and microphone path on the
+   mixer itself and have no equivalent control in Mixxx.


### PR DESCRIPTION
The page said no driver is available for Linux. There is one now, so note up front that a driver is required on every platform and link to it, and fill in the details that were missing.

- state that a driver must be installed before Mixxx sees the controller or its audio interface, with per-platform links
- document the MIDI/PHONO/LINE front panel switch, which otherwise makes a channel's gain, EQ and line fader look dead in Mixxx
- add the input channel assignment for the audio interface
- point at the Interface Edition page for the shared MIDI layout and list the two front panel controls this mapping adds

Open PRs:
-Linux driver: https://github.com/mischa85/Ozzy/pull/80
-Mapping: https://github.com/mixxxdj/mixxx/pull/16929