### PR TITLE
Document beats_translate_move control in appendix

### DIFF
--- a/source/chapters/appendix/mixxx_controls.rst
+++ b/source/chapters/appendix/mixxx_controls.rst
@@ -963,6 +963,22 @@ Any control listed above for :mixxx:cogroupref:`[ChannelN]` will work for a samp
    .. versionadded:: 2.0.0
 
 
+.. mixxx:control:: [ChannelN],beats_translate_move
+                   [PreviewDeckN],beats_translate_move
+                   [SamplerN],beats_translate_move
+
+   Move :term:`beatgrid` by the given number of ticks, earlier for negative
+   values and later for positive values. Each tick moves the beatgrid by a
+   small amount, equivalent to one press of
+   :mixxx:coref:`beats_translate_earlier <[ChannelN],beats_translate_earlier>`
+   or :mixxx:coref:`beats_translate_later <[ChannelN],beats_translate_later>`.
+
+   :range: relative value
+   :feedback: The beatgrid moves left or right by a small amount per tick.
+
+   .. versionadded:: 2.5.0
+
+
 .. mixxx:control:: [ChannelN],shift_cues_earlier
                    [PreviewDeckN],shift_cues_earlier
                    [SamplerN],shift_cues_earlier


### PR DESCRIPTION
## Summary
- Adding the `beats_translate_move` ControlEncoder entry to the controls appendix (`source/chapters/appendix/mixxx_controls.rst`), placed between `beats_translate_later` and `shift_cues_earlier`.
- Documents the relative-value encoder introduced in mixxxdj/mixxx#12376, with cross-references to the sibling `beats_translate_earlier`/`_later` buttons.
- Uses `:range: relative value` matching the encoder style of `[Playlist],SelectTrackKnob`, and `versionadded:: 2.5.0` matching the changelog attribution.

#### Test plan
- [x] English Sphinx build completes with no warnings on the changed file
- [x] All three group signatures (`[ChannelN]`, `[PreviewDeckN]`, `[SamplerN]`) render
- [x] Cross-reference links to `beats_translate_earlier`/`_later` resolve to correct anchors

Generated with [Devin](https://devin.ai)