### PR TITLE
Add changelog entry for waveform cache size GiB display

### DIFF
--- a/source/chapters/appendix/changelog.rst
+++ b/source/chapters/appendix/changelog.rst
@@ -184,6 +184,9 @@ Preferences
 * Interface: use main window screen to detect if skin fits
   `#15824 <https://github.com/mixxxdj/mixxx/pull/15824>`__
   `#15823 <https://github.com/mixxxdj/mixxx/issues/15823>`__
+* Waveforms: display cached waveforms size in GiB when >= 1024 MiB
+  `#15578 <https://github.com/mixxxdj/mixxx/pull/15578>`__
+  `#14874 <https://github.com/mixxxdj/mixxx/issues/14874>`__
 
 Skins
 ^^^^^


### PR DESCRIPTION
## Summary
- Adding a v2.5.6 changelog entry under Preferences for the waveform cache size display improvement from mixxxdj/mixxx#15578, which switches the display from MiB to GiB once the cache reaches 1024 MiB (fixing mixxxdj/mixxx#14874).

#### Test plan
- [x] English Sphinx build completes with no warnings on the changed file
- [x] Entry renders with both PR and issue links

Generated with [Devin](https://devin.ai)