### PR TITLE
Gitignore egg-info generated by pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 source/locale/pot/.doctrees
 /source/locale/en_US
+sphinx-mixxx/sphinx_mixxx.egg-info/


### PR DESCRIPTION
The .egg-info file is generated by PIP when installing Sphinx and other dependencies in a virtual environment. If you are using dependencies from your systems package manager, this file will not be created.

This was discussed in pull #736 but it never got merged and apparently I deleted this repo on my end at some point, which to GitHub, annoyingly, means "close the PR".